### PR TITLE
Implement stringsSepBy1 parser

### DIFF
--- a/Doc/src/reference-charparsers.txt
+++ b/Doc/src/reference-charparsers.txt
@@ -1158,8 +1158,8 @@ val @many1Strings2@: Parser<string,'u> -> Parser<string,'u> -> Parser<string,'u>
 val @stringsSepBy@: Parser<string,'u> -> Parser<string,'u> -> Parser<string,'u>
 ``]
 [
-`stringsSepBy sp sep` parses *zero* or more occurrences of `sp` separated by `sep`
-(in EBNF: `{EBNF}(p (sep p)*)?`). It returns the strings parsed by `p` *and* `sep` in concatenated form.
+`stringsSepBy sp sep` parses *zero* or more occurrences of the string parser `sp` separated by `sep`
+(in EBNF: `{EBNF}(sp (sep sp)*)?`). It returns the strings parsed by `sp` *and* `sep` in concatenated form.
 
 `stringsSepBy` behaves like `sepBy`, except that instead of returning a list of the results of only the first argument parser it returns a concatenated string of all strings returned by both argument parsers (in the sequence they occurred).
 
@@ -1186,6 +1186,16 @@ let stringLiteral =
             (stringsSepBy normalCharSnippet escapedChar)
 ``
 
+]
+
+[``
+val @stringsSepBy1@: Parser<string,'u> -> Parser<string,'u> -> Parser<string,'u>
+``]
+[
+`stringsSepBy1 sp sep` parses *one* or more occurrences of the string parser `sp` separated by `sep`
+(in EBNF: `{EBNF}(sp (sep sp)*)`). It returns the strings parsed by `sp` *and* `sep` in concatenated form.
+
+`stringsSepBy1` behaves like `stringsSepBy`, except that it fails without consuming input if `sp` does not match at least once.
 ]
 
 [``

--- a/FParsec/CharParsers.fsi
+++ b/FParsec/CharParsers.fsi
@@ -490,6 +490,10 @@ val many1Strings2: Parser<string,'u> -> Parser<string,'u> -> Parser<string,'u>
 /// It returns the strings parsed by `sp` *and* `sep` in concatenated form.
 val stringsSepBy: Parser<string,'u> -> Parser<string,'u> -> Parser<string,'u>
 
+/// `stringsSepBy1 sp sep` parses *one* or more occurrences of `sp` separated by `sep`.
+/// It returns the strings parsed by `sp` *and* `sep` in concatenated form.
+val stringsSepBy1: Parser<string,'u> -> Parser<string,'u> -> Parser<string,'u>
+
 /// `skipped p` applies the parser `p` and returns the chars skipped over by `p` as a string.
 /// All newlines ("\r\n", "\r" or "\n") are normalized to "\n".
 val skipped: Parser<unit,'u> -> Parser<string,'u>


### PR DESCRIPTION
This would fix #3.

I tried to write unit tests as well as implement the function, but I couldn't figure out how the existing `stringsSepBy` unit tests work in order to add a set of `stringsSepBy1` tests (just like `stringsSepBy` but rejecting the case where the first parser doesn't match even a single time). Besides which, it wasn't immediately obvious to me how to get the code compiling on my Linux development box with VS Code + Ionide, so I couldn't have run the unit tests even if I had written them.

So I'm afraid you'll have to write the unit tests and make sure my code is correct before merging it in. But it's a very straightforward change, and I could copy the logic from `manyStringsImpl` just above. So I'm pretty sure that it's correct, I just couldn't prove it with unit tests.