### PR TITLE
Add 'count' function

### DIFF
--- a/FParsec/Primitives.fs
+++ b/FParsec/Primitives.fs
@@ -915,6 +915,30 @@ let chainr1 p op =
 
 let chainr p op x = chainr1 p op <|>% x
 
+// Parser<('a -> 'b), 'u> -> Parser<'a, 'u> -> Parser<'b, 'u>
+let apply fp xp =
+    pipe2 fp xp (fun f x -> f x)
+
+// ('a -> Parser<'b, 'u>) -> 'a list -> Parser<'b list, 'u>
+let traverse f list =
+    let (<*>) = apply
+    let retn = preturn
+    let cons head tail = head :: tail
+     
+    let init = retn []
+    let folder head tail =
+        retn cons <*> (f head) <*> tail
+
+    List.foldBack folder list init
+
+// Parser<'a, 'u> list -> Parser<'a list, 'u>
+let sequence x = traverse id x
+
+// int -> Parser<'a, 'u> -> Parser<'a, 'u> list
+let count (n : int) (p : Parser<'a, 'u>) : Parser<'a list, 'u> =
+    match n with
+    | _ when n <= 0 -> preturn []
+    | _ -> sequence (List.replicate n p)
 
 // ------------------------------
 // Computation expression syntax

--- a/FParsec/Primitives.fsi
+++ b/FParsec/Primitives.fsi
@@ -307,6 +307,13 @@ val many1Till: Parser<'a,'u> -> Parser<'b,'u> -> Parser<'a list,'u>
 
 val skipMany1Till: Parser<'a,'u> -> Parser<'b,'u> -> Parser<unit,'u>
 
+val apply: Parser<('a -> 'b), 'u> -> Parser<'a, 'u> -> Parser<'b, 'u>
+
+val traverse: ('a -> Parser<'b, 'u>) -> 'a list -> Parser<'b list, 'u>
+
+val sequence: Parser<'a, 'u> list -> Parser<'a list, 'u>
+ 
+val count: int -> Parser<'a, 'u> -> Parser<'a list, 'u>
 
 [<Sealed>]
 type Inline =

--- a/Test/PrimitivesTests.fs
+++ b/Test/PrimitivesTests.fs
@@ -623,7 +623,48 @@ let testPrimitives() =
 
     testChain()
 
+    let testCount() =
+        // Assertions
+        let succ expected actual =
+             match actual with
+             | Success (res, _, _) -> Equal expected res
+             | Failure _ -> Fail ()
+        
+        let fail x =
+            match x with
+            | Success _ -> Fail ()
+            | Failure _ -> ()
+
+        // SUT
+        let pcount x p = FParsec.Primitives.count x p
+        
+        let runNums p = 
+            [1..5] 
+            |> List.map string 
+            |> List.reduce (+) 
+            |> (run <| p)
+
+        // Test if 'count' parses "12345" into [1; 2; 3; 4; 5]
+        let expected = [1..5] |> List.map (string >> char)
+        let actual = runNums <| pcount 5 digit
+        succ expected actual
+       
+        // Test if 'count' requires the given amount
+        fail (runNums <| pcount 6 digit)
+        
+        // Test if 'count' parses "AAAAAAAAAA" into ['A'; 'A'; ... ]
+        let expected = List.replicate 10 'A'
+        
+        let runAA p =
+            expected
+            |> List.map string
+            |> List.reduce (+)
+            |> (run <| p)
+
+        let actual = runAA <| pcount 10 (pchar 'A')
+        succ expected actual
+    
+    testCount()
 
 let run() =
     testPrimitives()
-


### PR DESCRIPTION
I needed a ```count``` function for some project (like **Parsec** has), so I implemented it.
I would love to use _FsCheck_ for this but had some problems with installation.
That's why I added three test cases:

- To test if the ```count``` function successfully parses a required amount of parsers
- To test if the ```count``` function fails when the required amount of parsers isn't met
- To tes if the ```count``` function successfully parses another required amount of parsers (to test if the ```count``` function not only works for ```int```'s but for any type).

I would love to hear your feedback!