### PR TITLE
Fixing a null reference on Position.StreamName

### DIFF
--- a/FParsecCS/CharStreamLT.cs
+++ b/FParsecCS/CharStreamLT.cs
@@ -215,6 +215,7 @@ public class CharStream : IDisposable {
                                        FileShare.Read, 4096, FileOptions.SequentialScan);
         try {
            StreamConstructorContinue(stream, false, encoding, detectEncodingFromByteOrderMarks, byteBufferLength);
+           _Name = path;
         } catch {
             stream.Dispose();
             throw;


### PR DESCRIPTION
I found this bug when using the low trust edition through `runParserOnFile`. Tests on my development machine showed no issue with the patch.