### PR TITLE
 use source link instead of separate symbols

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.7.2" PrivateAssets="All" /> 
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.7.4" PrivateAssets="All" /> 
   </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.7.2" PrivateAssets="All" /> 
+  </ItemGroup>
+</Project>

--- a/pack.ps1
+++ b/pack.ps1
@@ -38,7 +38,7 @@ foreach ($config in $configs) {
     $props = "/p:Configuration=$config /p:VersionSuffix=$versionSuffix /p:FParsecNuGet=true"
     invoke "msbuild /t:Restore $props"
     invoke "msbuild /t:Clean $props"
-    invoke "msbuild FParsec /t:Build $props"
+    invoke "msbuild FParsec /t:Build /p:SourceLinkCreate=true $props"
     invoke "msbuild Test /t:Build $props"
     foreach ($tf in $testTargetFrameworks[$config]) {
         if ($tf.StartsWith('netcoreapp')) {
@@ -48,19 +48,11 @@ foreach ($config in $configs) {
         }
     }
     invoke "msbuild /t:Restore $props /p:MergedFParsecPackage=true"
-    invoke "msbuild /t:Pack /p:NoBuild=true /p:IncludeSource=true /p:IncludeSymbols=true $props /p:MergedFParsecPackage=true"
+    invoke "msbuild /t:Pack /p:NoBuild=true /p:IncludeSource=true $props /p:MergedFParsecPackage=true"
     if (($config -eq 'Release-LowTrust') -and $testPCL) {
         $pclProps = "/p:TargetFramework=net45 /p:OutputPath=bin\$config\net45-pcl\ /p:TestPCLFParsec=true $props"
         invoke "msbuild Test/Test.fsproj /t:Clean $pclProps"
         invoke "msbuild Test/Test.fsproj /t:Build $pclProps"
         invoke ".\Test\bin\$config\net45-pcl\Test.exe"
     }
-}
-
-# The non-symbol packages built by the msbuild Pack target include some files only belonging
-# into the symbol packages, so we have to recreate the packages from the generated nuspecs.
-foreach ($nuspec in Get-ChildItem -Path ".\FParsec\obj\" -Recurse -Include "FParsec*.symbols.nuspec") {
-    $localNuspecPath = ".\$($nuspec.Name.Replace('.symbols', [string]::Empty))"
-    Copy-Item $nuspec $localNuspecPath -verbose
-    invoke ".\nuget pack $localNuspecPath -Symbols"
 }

--- a/pack.ps1
+++ b/pack.ps1
@@ -48,7 +48,7 @@ foreach ($config in $configs) {
         }
     }
     invoke "msbuild /t:Restore $props /p:MergedFParsecPackage=true"
-    invoke "msbuild /t:Pack /p:NoBuild=true /p:IncludeSource=true $props /p:MergedFParsecPackage=true"
+    invoke "msbuild /t:Pack /p:NoBuild=true $props /p:MergedFParsecPackage=true"
     if (($config -eq 'Release-LowTrust') -and $testPCL) {
         $pclProps = "/p:TargetFramework=net45 /p:OutputPath=bin\$config\net45-pcl\ /p:TestPCLFParsec=true $props"
         invoke "msbuild Test/Test.fsproj /t:Clean $pclProps"


### PR DESCRIPTION
This enabled source link for the main nupkg files. Instead of separate symbols/src files, the pdb files are included in the nupkg files published to NuGet Gallery. 

https://github.com/ctaggart/sourcelink

```
C:\Users\camer\cs\SourceLink\build [bump ≡]> dotnet sourcelink print-json "C:\Users\camer\fs\fparsec\FParsec\bin\Release\FParsec-Big-Data-Edition.1.0.4-dev\lib\net45\FParsecCS.pdb"
{"documents":{"C:\\Users\\camer\\fs\\fparsec\\*":"https://raw.githubusercontent.com/stephan-tolksdorf/fparsec/8f3477745f1f133ff8102ae3a2668e858fb9f647/*"}}
C:\Users\camer\cs\SourceLink\build [bump ≡]> dotnet sourcelink test "C:\Users\camer\fs\fparsec\FParsec\bin\Release\FParsec-Big-Data-Edition.1.0.4-dev\lib\net45\FParsecCS.pdb"
sourcelink test passed: C:\Users\camer\fs\fparsec\FParsec\bin\Release\FParsec-Big-Data-Edition.1.0.4-dev\lib\net45\FParsecCS.pdb
```