### PR TITLE
Sign assemblies for all target frameworks.

### DIFF
--- a/Build/FParsec.Common.targets
+++ b/Build/FParsec.Common.targets
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(FParsecNuGet)' == 'true'">
-    <SignAssembly Condition="'$(TargetFramework)' == 'net45'">true</SignAssembly>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Rationale is here: https://github.com/stephan-tolksdorf/fparsec/issues/53#issuecomment-611474683

We've built our own strongly named .nuget and placed it in our private nuget source, but i think that it would be better if official packages were fully signed too.