### PR TITLE
Run CI on Pull Requests and when pushing to master only.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: Build and test
 
 on:
   push:
+    branches: [master]
+  pull_request:
 
 jobs:
   build-and-test-low-trust:


### PR DESCRIPTION
The changes in #97 did not make CI run on #92. This PR fixes that.

The CI workflow is enabled to run on Pull Requests, and on pushes it will run only when pushing to `master`. This way duplicate runs will be avoided.