### PR TITLE
Modernize FParsec's test framework

### DIFF
--- a/Test/AllTests.fs
+++ b/Test/AllTests.fs
@@ -4,8 +4,6 @@
 
 
 let run() =
-    printfn "Testing FParsec.CharSet ..."
-    FParsec.Test.CharSetTests.run()
     printfn "Testing FParsec.HexFloat ..."
     FParsec.Test.HexFloatTests.run()
     printfn "Testing FParsec.Text ..."

--- a/Test/AllTests.fs
+++ b/Test/AllTests.fs
@@ -1,10 +1,9 @@
-﻿// Copyright (c) Stephan Tolksdorf 2007-2011
+﻿module AllTests
+// Copyright (c) Stephan Tolksdorf 2007-2011
 // License: Simplified BSD License. See accompanying documentation.
 
 
 let run() =
-    printfn "Testing FParsec.Buffer ..."
-    FParsec.Test.BufferTests.run()
     printfn "Testing FParsec.CharSet ..."
     FParsec.Test.CharSetTests.run()
     printfn "Testing FParsec.HexFloat ..."
@@ -40,17 +39,17 @@ let run() =
 #endif
     printfn "No error was found."
 
-[<EntryPoint>]
-let main _argv =
-
-#if NETCOREAPP
-    System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
-#endif
-
-    try
-        run()
-        0
-    with
-    | ex ->
-        printfn $"error: {ex}"
-        1
+// [<EntryPoint>]
+// let main _argv =
+//
+// #if NETCOREAPP
+//     System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+// #endif
+//
+//     try
+//         run()
+//         0
+//     with
+//     | ex ->
+//         printfn $"error: {ex}"
+//         1

--- a/Test/AllTests.fs
+++ b/Test/AllTests.fs
@@ -4,8 +4,6 @@
 
 
 let run() =
-    printfn "Testing FParsec.HexFloat ..."
-    FParsec.Test.HexFloatTests.run()
     printfn "Testing FParsec.Text ..."
     FParsec.Test.TextTests.run()
 #if !LOW_TRUST

--- a/Test/CharSetTests.fs
+++ b/Test/CharSetTests.fs
@@ -3,52 +3,31 @@
 
 module FParsec.Test.CharSetTests
 
-open FParsec.Test.Test
+open System
+open Xunit
+open FsCheck
 
-let basicTests() =
-    let test s (sin: string) (sout: string) =
-        let cs = FParsec.CharSet(s)
-        for c in sin do
-            cs.Contains(c) |> True
-        for c in sout do
-            cs.Contains(c) |> False
+[<FParsecProperty>]
+let ``Calling Contains returns true when the CharSet contains the character`` (NonEmptyString charSet) =
+    let cs = FParsec.CharSet(charSet)
+    
+    charSet |> Seq.forall cs.Contains
 
-    test "" "" "a\u0000\uffff"
-    test "a" "a" "\u0000\uffff"
-    test "\u0000\uffffa" "a\u0000\uffffa" "b\u0001\ufffe"
-    test "\u0002\u0001\u0399\u0400\u0401\u0399\u0400\u0401\uffffabc123" "\u0002\u0001\u0399\u0400\u0401\uffffabc123" "\u0000\u0398\u0402\ufffed0"
+[<FParsecProperty>]
+let ``Calling Contains returns false when the CharSet does not contain the character`` (NonEmptyString charSet) =
+    let filteredChar = charSet[0]
+    let filteredCharSet =
+        charSet
+        |> String.filter (fun c -> c <> filteredChar)
+    
+    let cs = FParsec.CharSet(filteredCharSet)
+    
+    not <| cs.Contains filteredChar
 
+[<Fact>]
+let ``Creating a CharSet with a null string throws a NullReferenceException`` () =
+    Assert.Throws<NullReferenceException>(fun () -> FParsec.CharSet(null) |> ignore )
 
-let moreTests() =
-    let rand = new System.Random(12345)
-
-    for j = 0 to 20000 do
-        let n = rand.Next(1, 100)
-        let cs = Array.zeroCreate n
-        for i = 1 to n/2 do
-            let r = rand.Next()
-            cs[i*2 - 2] <- char r
-            cs[i*2 - 1] <- char (r >>> 16)
-        if n%2 = 1 then cs[cs.Length - 1] <- char (rand.Next())
-
-        let set = FParsec.CharSet(new string(cs))
-
-        Array.sortInPlace cs
-
-        let mutable c_1 = '\uffff'
-        let mutable c = cs[0]
-
-        for i = 0 to n - 1 do
-            set.Contains(c) |> True
-            if c <> c_1 && int c - 1 <> int c_1 then
-                set.Contains(char (int c - 1)) |> False
-            if i + 1 < n then
-                let c1 = cs[i + 1]
-                if c < '\uffff' && c <> c1 && int c + 1 <> int c1 then
-                    set.Contains(char (int c + 1)) |> False
-                c_1 <- c
-                c <- c1
-
-let run() =
-    basicTests()
-    moreTests()
+[<FParsecProperty>]
+let ``Calling Contains returns false for any character when the CharSet is empty`` (c: char) =
+    not <| FParsec.CharSet("").Contains(c)

--- a/Test/Common.fs
+++ b/Test/Common.fs
@@ -1,6 +1,135 @@
 ﻿[<AutoOpen>]
 module FParsec.Test.Common
 
+open System
+open System.Collections
+open System.Text.RegularExpressions
 open FsCheck
 
+
 let (===) left right = left = right |@ $"%A{left} != %A{right}"
+
+let (.*) input pattern = Regex.Match(input, pattern).Success |@ $"String: '{input}' doesn't match the pattern."
+
+module Float =
+    type private FloatParts =
+        {
+            Sign : int64
+            Exponent : int64
+            Fraction : int64
+        }
+    
+    let private getFloatParts (f: float) =
+        let ( ** ) v e =
+            seq { for _ in 1 .. e do yield v }
+            |> Seq.fold (fun acc v -> acc * v) 1L
+        
+        let bitsToLong (bits: int64 list) =
+            let rec loop (place: int) (acc: int64) (bits: int64 list) =
+                match bits with
+                | head :: tail ->
+                    let acc' = acc + ((2L ** place) * head)
+                    loop (place + 1) acc' tail
+                | [] ->
+                    acc
+            
+            bits
+            |> loop 0 0
+            
+        
+        let bytes = BitConverter.GetBytes f
+        let mutable bits : bool array = Array.zeroCreate 64
+        BitArray(bytes).CopyTo(bits, 0)
+        
+        let bits' =
+            bits
+            |> List.ofArray
+            |> List.map (fun b -> if b then 1L else 0L)
+        
+        let sign = bits'[63]
+        let exponent = bits'[52..62]
+        let fraction = bits'[0..51]
+        
+        {
+            Sign = sign
+            Exponent = exponent |> bitsToLong
+            Fraction = fraction |> bitsToLong
+        }
+    
+    let private hexValue = function
+        | 0uy -> '0'
+        | 1uy -> '1'
+        | 2uy -> '2'
+        | 3uy -> '3'
+        | 4uy -> '4'
+        | 5uy -> '5'
+        | 6uy -> '6'
+        | 7uy -> '7'
+        | 8uy -> '8'
+        | 9uy -> '9'
+        | 10uy -> 'a'
+        | 11uy -> 'b'
+        | 12uy -> 'c'
+        | 13uy -> 'd'
+        | 14uy -> 'e'
+        | 15uy -> 'f'
+        | x -> failwith $"{x} is out of range for hex digit"
+    
+    let private fractionString floatParts =
+        let splitByte (b: byte) =
+            let top = b &&& 240uy >>> 4
+            let bottom = b &&& 15uy
+            [|bottom; top|]
+        
+        floatParts.Fraction                      // 3934024402416481L
+        |> BitConverter.GetBytes                // [|97uy; 51uy; 11uy; 111uy; 249uy; 249uy; 13uy; 0uy|]
+        |> Array.collect splitByte              // [|1uy; 6uy; 3uy; 3uy; 11uy; 0uy; 15uy; 6uy; 9uy; 15uy; 9uy; 15uy; 13uy; 0uy; 0uy; 0uy|]
+        |> Array.take 13                        // [|1uy; 6uy; 3uy; 3uy; 11uy; 0uy; 15uy; 6uy; 9uy; 15uy; 9uy; 15uy; 13uy;|]
+        |> Array.map hexValue                   // [|'1'; '6'; '3'; '3'; 'b'; '0'; 'f'; '6'; '9'; 'f'; '9'; 'f'; 'd'|]
+        |> Array.skipWhile (fun c -> c = '0')   // [|'1'; '6'; '3'; '3'; 'b'; '0'; 'f'; '6'; '9'; 'f'; '9'; 'f'; 'd'|]
+        |> Array.rev                            // [|'d'; 'f'; '9'; 'f'; '9'; '6'; 'f'; '0'; 'b'; '3'; '3'; '6'; '1'|]
+        |> String                                    // "df9f96f0b3361"
+    
+    let private exponentString floatParts =
+        let bias = 1023L
+        
+        floatParts.Exponent
+        |> fun e -> e - bias
+        |> Convert.ToString
+    
+    let private signString floatParts =
+        if floatParts.Sign = 1L
+        then "-"
+        else ""
+    
+    let private (|Zero|Normal|SubNormal|Infinity|NaN|) floatParts =
+        match floatParts.Exponent, floatParts.Fraction with
+        | 0L, 0L -> Zero
+        | 0L, _ -> SubNormal
+        | 2047L, 0L -> Infinity
+        | 2047L, _ -> NaN
+        | _, _ -> Normal
+    
+    let private floatPartsToHexString floatParts =
+        let sign =
+            floatParts
+            |> signString
+        
+        let fraction =
+            floatParts
+            |> fractionString
+
+        let exponent =
+            floatParts
+            |> exponentString
+        
+        match floatParts with
+        | Zero ->       $"{sign}0x0.0p0"
+        | SubNormal ->  $"{sign}0x0.{fraction}p-1022"
+        | Infinity ->   $"{sign}Infinity"
+        | NaN ->        "NaN"
+        | Normal ->     $"{sign}0x1.{fraction}p{exponent}"
+    
+    let toHexString (f: float) =
+        getFloatParts f
+        |> floatPartsToHexString

--- a/Test/Common.fs
+++ b/Test/Common.fs
@@ -1,0 +1,6 @@
+﻿[<AutoOpen>]
+module FParsec.Test.Common
+
+open FsCheck
+
+let (===) left right = left = right |@ $"%A{left} != %A{right}"

--- a/Test/Common.fs
+++ b/Test/Common.fs
@@ -47,16 +47,16 @@ module Float =
             |> List.map (fun b -> if b then 1L else 0L)
         
         let sign = bits'[63]
-        let exponent = bits'[52..62]
-        let fraction = bits'[0..51]
+        let exponent = bits'[52..62] |> bitsToLong
+        let fraction = bits'[0..51] |> bitsToLong
         
         {
             Sign = sign
-            Exponent = exponent |> bitsToLong
-            Fraction = fraction |> bitsToLong
+            Exponent = exponent
+            Fraction = fraction
         }
     
-    let private hexValue = function
+    let private toHexValue = function
         | 0uy -> '0'
         | 1uy -> '1'
         | 2uy -> '2'
@@ -75,6 +75,26 @@ module Float =
         | 15uy -> 'f'
         | x -> failwith $"{x} is out of range for hex digit"
     
+    let private fromHexValue c =
+        match Char.ToLower c with
+        | '0' -> 0uy
+        | '1' -> 1uy
+        | '2' -> 2uy
+        | '3' -> 3uy
+        | '4' -> 4uy
+        | '5' -> 5uy
+        | '6' -> 6uy
+        | '7' -> 7uy
+        | '8' -> 8uy
+        | '9' -> 9uy
+        | 'a' -> 10uy
+        | 'b' -> 11uy
+        | 'c' -> 12uy
+        | 'd' -> 13uy
+        | 'e' -> 14uy
+        | 'f' -> 15uy
+        | x -> failwith $"{x} is not a valid hex digit"
+    
     let private fractionString floatParts =
         let splitByte (b: byte) =
             let top = b &&& 240uy >>> 4
@@ -85,7 +105,7 @@ module Float =
         |> BitConverter.GetBytes                // [|97uy; 51uy; 11uy; 111uy; 249uy; 249uy; 13uy; 0uy|]
         |> Array.collect splitByte              // [|1uy; 6uy; 3uy; 3uy; 11uy; 0uy; 15uy; 6uy; 9uy; 15uy; 9uy; 15uy; 13uy; 0uy; 0uy; 0uy|]
         |> Array.take 13                        // [|1uy; 6uy; 3uy; 3uy; 11uy; 0uy; 15uy; 6uy; 9uy; 15uy; 9uy; 15uy; 13uy;|]
-        |> Array.map hexValue                   // [|'1'; '6'; '3'; '3'; 'b'; '0'; 'f'; '6'; '9'; 'f'; '9'; 'f'; 'd'|]
+        |> Array.map toHexValue                   // [|'1'; '6'; '3'; '3'; 'b'; '0'; 'f'; '6'; '9'; 'f'; '9'; 'f'; 'd'|]
         |> Array.skipWhile (fun c -> c = '0')   // [|'1'; '6'; '3'; '3'; 'b'; '0'; 'f'; '6'; '9'; 'f'; '9'; 'f'; 'd'|]
         |> Array.rev                            // [|'d'; 'f'; '9'; 'f'; '9'; '6'; 'f'; '0'; 'b'; '3'; '3'; '6'; '1'|]
         |> String                                    // "df9f96f0b3361"
@@ -131,5 +151,149 @@ module Float =
         | Normal ->     $"{sign}0x1.{fraction}p{exponent}"
     
     let toHexString (f: float) =
+        getFloatParts f
+        |> floatPartsToHexString
+
+module Float32 =
+    type private FloatParts =
+        {
+            Sign : int
+            Exponent : int
+            Fraction : int
+        }
+    
+    let private getFloatParts (f: float32) =
+        let ( ** ) v e =
+            seq { for _ in 1 .. e do yield v }
+            |> Seq.fold (fun acc v -> acc * v) 1
+        
+        let bitsToInt (bits: int list) =
+            let rec loop (place: int) (acc: int) (bits: int list) =
+                match bits with
+                | head :: tail ->
+                    let acc' = acc + ((2 ** place) * head)
+                    loop (place + 1) acc' tail
+                | [] ->
+                    acc
+            
+            bits
+            |> loop 0 0
+            
+        
+        let bytes = BitConverter.GetBytes f
+        let mutable bits : bool array = Array.zeroCreate 32
+        BitArray(bytes).CopyTo(bits, 0)
+        
+        let bits' =
+            bits
+            |> List.ofArray
+            |> List.map (fun b -> if b then 1 else 0)
+        
+        let sign = bits'[31]
+        let exponent = bits'[23..30] |> bitsToInt
+        let fraction = bits'[0..22] |> bitsToInt
+        
+        {
+            Sign = sign
+            Exponent = exponent
+            Fraction = fraction
+        }
+    
+    let private toHexValue = function
+        | 0uy -> '0'
+        | 1uy -> '1'
+        | 2uy -> '2'
+        | 3uy -> '3'
+        | 4uy -> '4'
+        | 5uy -> '5'
+        | 6uy -> '6'
+        | 7uy -> '7'
+        | 8uy -> '8'
+        | 9uy -> '9'
+        | 10uy -> 'a'
+        | 11uy -> 'b'
+        | 12uy -> 'c'
+        | 13uy -> 'd'
+        | 14uy -> 'e'
+        | 15uy -> 'f'
+        | x -> failwith $"{x} is out of range for hex digit"
+    
+    let private fromHexValue c =
+        match Char.ToLower c with
+        | '0' -> 0uy
+        | '1' -> 1uy
+        | '2' -> 2uy
+        | '3' -> 3uy
+        | '4' -> 4uy
+        | '5' -> 5uy
+        | '6' -> 6uy
+        | '7' -> 7uy
+        | '8' -> 8uy
+        | '9' -> 9uy
+        | 'a' -> 10uy
+        | 'b' -> 11uy
+        | 'c' -> 12uy
+        | 'd' -> 13uy
+        | 'e' -> 14uy
+        | 'f' -> 15uy
+        | x -> failwith $"{x} is not a valid hex digit"
+    
+    let private fractionString floatParts =
+        let splitByte (b: byte) =
+            let top = b &&& 240uy >>> 4
+            let bottom = b &&& 15uy
+            [|bottom; top|]
+        
+        floatParts.Fraction                       // 4788187
+        |> fun f -> f <<< 1                       // 9576374 I'm still not sure why this is required
+        |> BitConverter.GetBytes                // [|182uy; 31uy; 146uy; 0uy|]
+        |> Array.collect splitByte              // [|6uy; 11uy; 15uy; 1uy; 2uy; 9uy; 0uy; 0uy|]
+        |> Array.take 6                         // [|6uy; 11uy; 15uy; 1uy; 2uy; 9uy|]
+        |> Array.map toHexValue                 // [|'6'; 'b'; 'f'; '1'; '2'; '9'|]
+        |> Array.skipWhile (fun c -> c = '0')   // [|'6'; 'b'; 'f'; '1'; '2'; '9'|]
+        |> Array.rev                            // [|'9'; '2'; '1'; 'f'; 'b'; '6'|]
+        |> String                                    // "921fb6"
+    
+    let private exponentString floatParts =
+        let bias = 127
+        
+        floatParts.Exponent
+        |> fun e -> e - bias
+        |> Convert.ToString
+    
+    let private signString floatParts =
+        if floatParts.Sign = 1
+        then "-"
+        else ""
+    
+    let private (|Zero|Normal|SubNormal|Infinity|NaN|) floatParts =
+        match floatParts.Exponent, floatParts.Fraction with
+        | 0, 0 -> Zero
+        | 0, _ -> SubNormal
+        | 255, 0 -> Infinity
+        | 255, _ -> NaN
+        | _, _ -> Normal
+    
+    let private floatPartsToHexString floatParts =
+        let sign =
+            floatParts
+            |> signString
+        
+        let fraction =
+            floatParts
+            |> fractionString
+
+        let exponent =
+            floatParts
+            |> exponentString
+        
+        match floatParts with
+        | Zero ->       $"{sign}0x0.0p0"
+        | SubNormal ->  $"{sign}0x0.{fraction}p-126"
+        | Infinity ->   $"{sign}Infinity"
+        | NaN ->        "NaN"
+        | Normal ->     $"{sign}0x1.{fraction}p{exponent}"
+    
+    let toHexString (f: float32) =
         getFloatParts f
         |> floatPartsToHexString

--- a/Test/Generators.fs
+++ b/Test/Generators.fs
@@ -1,0 +1,29 @@
+﻿[<AutoOpen>]
+module FParsec.Test.Generators
+
+open FsCheck
+open FsCheck.Xunit
+
+let shrink validator t =
+        Arb.Default.Derive().Shrinker t
+        |> Seq.filter validator
+
+type NonEmptyArray<'t> = NonEmptyArray of 't array with
+    static member op_Explicit(NonEmptyArray arr) = arr
+    
+    static member generator =
+        Arb.generate<'t array>
+        |> Gen.filter (fun g -> g.Length > 0)
+        |> Gen.map NonEmptyArray
+    
+    static member valid (NonEmptyArray arr) =
+        arr.Length > 0
+    
+    static member shrink = shrink NonEmptyArray.valid
+    
+type FParsecGenerators =
+    static member NonEmptyArray () =
+        Arb.fromGenShrink (NonEmptyArray.generator, NonEmptyArray.shrink)
+
+type FParsecPropertyAttribute () =
+    inherit PropertyAttribute(Arbitrary = [| typeof<FParsecGenerators> |])

--- a/Test/Generators.fs
+++ b/Test/Generators.fs
@@ -63,6 +63,47 @@ type NegativeFiniteFloat = NegativeFiniteFloat of float with
     
     static member shrink = shrink NegativeFiniteFloat.valid
 
+type FiniteFloat32 = FiniteFloat32 of float32 with
+    static member op_Explicit(FiniteFloat32 f) = f
+    
+    static member generator =
+        Arb.generate<float32>
+        |> Gen.filter Single.IsFinite
+        |> Gen.map FiniteFloat32
+    
+    static member valid (FiniteFloat32 f) =
+        Single.IsFinite f
+    
+    static member shrink = shrink FiniteFloat32.valid
+
+type PositiveFiniteFloat32 = PositiveFiniteFloat32 of float32 with
+    static member op_Explicit(PositiveFiniteFloat32 f) = f
+    
+    static member generator =
+        Arb.generate<float32>
+        |> Gen.filter Single.IsFinite
+        |> Gen.filter (not << Single.IsNegative)
+        |> Gen.map PositiveFiniteFloat32
+    
+    static member valid (PositiveFiniteFloat32 f) =
+        Single.IsFinite f && (not << Single.IsNegative) f
+    
+    static member shrink = shrink PositiveFiniteFloat32.valid
+
+type NegativeFiniteFloat32 = NegativeFiniteFloat32 of float32 with
+    static member op_Explicit(NegativeFiniteFloat32 f) = f
+    
+    static member generator =
+        Arb.generate<float32>
+        |> Gen.filter Single.IsFinite
+        |> Gen.filter Single.IsNegative
+        |> Gen.map NegativeFiniteFloat32
+    
+    static member valid (NegativeFiniteFloat32 f) =
+        Single.IsFinite f && Single.IsNegative f
+    
+    static member shrink = shrink NegativeFiniteFloat32.valid
+
 type FParsecGenerators =
     static member NonEmptyArray () =
         Arb.fromGenShrink (NonEmptyArray.generator, NonEmptyArray.shrink)
@@ -75,6 +116,15 @@ type FParsecGenerators =
     
     static member NegativeFiniteFloat () =
         Arb.fromGenShrink (NegativeFiniteFloat.generator, NegativeFiniteFloat.shrink)
+    
+    static member FiniteFloat32 () =
+        Arb.fromGenShrink (FiniteFloat32.generator, FiniteFloat32.shrink)
+    
+    static member PositiveFiniteFloat32 () =
+        Arb.fromGenShrink (PositiveFiniteFloat32.generator, PositiveFiniteFloat32.shrink)
+    
+    static member NegativeFiniteFloat32 () =
+        Arb.fromGenShrink (NegativeFiniteFloat32.generator, NegativeFiniteFloat32.shrink)
 
 type FParsecPropertyAttribute () =
     inherit PropertyAttribute(Arbitrary = [| typeof<FParsecGenerators> |])

--- a/Test/Generators.fs
+++ b/Test/Generators.fs
@@ -1,6 +1,7 @@
 ﻿[<AutoOpen>]
 module FParsec.Test.Generators
 
+open System
 open FsCheck
 open FsCheck.Xunit
 
@@ -20,10 +21,60 @@ type NonEmptyArray<'t> = NonEmptyArray of 't array with
         arr.Length > 0
     
     static member shrink = shrink NonEmptyArray.valid
+
+type FiniteFloat = FiniteFloat of float with
+    static member op_Explicit(FiniteFloat f) = f
     
+    static member generator =
+        Arb.generate<float>
+        |> Gen.filter Double.IsFinite
+        |> Gen.map FiniteFloat
+    
+    static member valid (FiniteFloat f) =
+        Double.IsFinite f
+    
+    static member shrink = shrink FiniteFloat.valid
+
+type PositiveFiniteFloat = PositiveFiniteFloat of float with
+    static member op_Explicit(PositiveFiniteFloat f) = f
+    
+    static member generator =
+        Arb.generate<float>
+        |> Gen.filter Double.IsFinite
+        |> Gen.filter (not << Double.IsNegative)
+        |> Gen.map PositiveFiniteFloat
+    
+    static member valid (PositiveFiniteFloat f) =
+        Double.IsFinite f && (not << Double.IsNegative) f
+    
+    static member shrink = shrink PositiveFiniteFloat.valid
+
+type NegativeFiniteFloat = NegativeFiniteFloat of float with
+    static member op_Explicit(NegativeFiniteFloat f) = f
+    
+    static member generator =
+        Arb.generate<float>
+        |> Gen.filter Double.IsFinite
+        |> Gen.filter Double.IsNegative
+        |> Gen.map NegativeFiniteFloat
+    
+    static member valid (NegativeFiniteFloat f) =
+        Double.IsFinite f && Double.IsNegative f
+    
+    static member shrink = shrink NegativeFiniteFloat.valid
+
 type FParsecGenerators =
     static member NonEmptyArray () =
         Arb.fromGenShrink (NonEmptyArray.generator, NonEmptyArray.shrink)
+    
+    static member FiniteFloat () =
+        Arb.fromGenShrink (FiniteFloat.generator, FiniteFloat.shrink)
+    
+    static member PositiveFiniteFloat () =
+        Arb.fromGenShrink (PositiveFiniteFloat.generator, PositiveFiniteFloat.shrink)
+    
+    static member NegativeFiniteFloat () =
+        Arb.fromGenShrink (NegativeFiniteFloat.generator, NegativeFiniteFloat.shrink)
 
 type FParsecPropertyAttribute () =
     inherit PropertyAttribute(Arbitrary = [| typeof<FParsecGenerators> |])

--- a/Test/HexFloat32Tests.fs
+++ b/Test/HexFloat32Tests.fs
@@ -1,0 +1,441 @@
+﻿// Copyright (c) Stephan Tolksdorf 2008-2010
+// License: Simplified BSD License. See accompanying documentation.
+
+module FParsec.Test.HexFloat32Tests
+
+open System
+open Microsoft.FSharp.Core
+open Xunit
+open FParsec.Test.Test
+
+let float32ToHexString = FParsec.CharParsers.float32ToHexString
+let float32OfHexString = FParsec.CharParsers.float32OfHexString
+let eps    = (float32) (Math.Pow(2.0, -24.0))
+let min    = (float32) (Math.Pow(2.0, -126.0)) // smallest normal number
+let minmin = (float32) (Math.Pow(2.0, -149.0)) // smallest subnormal number
+
+[<FParsecProperty(MaxTest = 100000)>]
+let ``float32ToHexString output matches test oracle implementation`` (f: float32) =
+    float32ToHexString f === Float32.toHexString f
+
+[<FParsecProperty>]
+let ``float32ToHexString returns strings in the correct format`` (FiniteFloat32 f) =
+    float32ToHexString f .* @"(-?0x[01].[0-9a-fA-F]*p-?[0-9]*$)"
+
+[<FParsecProperty(MaxTest = 100000)>]
+let ``float32ToHexString and floatOfHexString functions are reciprocal`` (FiniteFloat32 f) =
+    (float32ToHexString f |> float32OfHexString) === f
+
+[<FParsecProperty>]
+let ``float32ToHexString returns strings that start with '0' for positive finite values`` (PositiveFiniteFloat32 f) =
+    let expected = '0'
+    
+    let actual = (float32ToHexString f)[0]
+    
+    expected === actual
+
+[<FParsecProperty>]
+let ``Hex String starts with '-' for negative finite values`` (NegativeFiniteFloat32 f) =
+    let expected = '-'
+    
+    let actual = (float32ToHexString f)[0]
+    
+    expected === actual
+
+[<Fact>]
+let ``float32ToHexString returns 'Infinity' for a positive infinity value`` () =
+    Assert.Equal("Infinity", float32ToHexString Single.PositiveInfinity)
+
+[<Fact>]
+let ``float32ToHexString returns '-Infinity' for a negative infinity value`` () =
+    Assert.Equal("-Infinity", float32ToHexString Single.NegativeInfinity)
+
+[<Fact>]
+let ``float32ToHexString returns 'NaN' for an invalid float value`` () =
+    Assert.Equal("NaN", float32ToHexString Single.NaN)
+
+[<Fact>]
+let ``Positive Zero exponent`` () =
+    Assert.Equal("0x0.0p0", float32ToHexString 0.0f)
+
+[<Fact>]
+let ``Negative Zero exponent`` () =
+    Assert.Equal("-0x0.0p0", float32ToHexString -0.0f)
+
+[<Theory>]
+[<InlineData("")>]
+[<InlineData(".")>]
+[<InlineData("p1")>]
+[<InlineData(".p1")>]
+[<InlineData("1x1")>]
+[<InlineData("x1")>]
+[<InlineData("0xx1")>]
+[<InlineData("0x/")>]
+[<InlineData("0x:")>]
+[<InlineData("0x@")>]
+[<InlineData("0xG")>]
+[<InlineData("0x`")>]
+[<InlineData("0xg")>]
+[<InlineData("0.1pp1")>]
+[<InlineData("0.1p+")>]
+[<InlineData("0.1p-")>]
+[<InlineData("0.fg")>]
+[<InlineData("1.0 ")>]
+[<InlineData("1..")>]
+[<InlineData("1.0.")>]
+let ``floatOfHexString correctly rejects malformed hex strings`` str =
+    Assert.Throws<FormatException>(fun () -> float32OfHexString str |> ignore)
+
+[<Fact>]
+let ``floatOfHexString correctly rejects a null string`` () =
+    Assert.Throws<ArgumentNullException>(fun () -> float32OfHexString null |> ignore)
+
+[<Theory>]
+[<InlineData("Inf", Double.PositiveInfinity)>]
+[<InlineData("iNf", Double.PositiveInfinity)>]
+[<InlineData("Infinity", Double.PositiveInfinity)>]
+[<InlineData("+InFinITy", Double.PositiveInfinity)>]
+[<InlineData("-Inf", Double.NegativeInfinity)>]
+[<InlineData("-InFinITy", Double.NegativeInfinity)>]
+[<InlineData("NaN", Double.NaN)>]
+[<InlineData("-nAn", Double.NaN)>]
+[<InlineData("+Nan", Double.NaN)>]
+let ``floatOfHexString correctly handles Infinity and NaN strings`` str expected =
+    Assert.Equal(expected, float32OfHexString str)
+
+[<Theory>]
+[<InlineData("001")>]
+[<InlineData("1.")>]
+[<InlineData("1.0")>]
+[<InlineData("0x1")>]
+[<InlineData("0X1")>]
+[<InlineData("0x0001")>]
+[<InlineData("0x1.")>]
+[<InlineData("0x1.0")>]
+[<InlineData("0x001.0")>]
+[<InlineData("1.0p0")>]
+[<InlineData("1.0P0")>]
+[<InlineData("001.00p+000")>]
+[<InlineData(".100p+004")>]
+[<InlineData(".0100p+008")>]
+[<InlineData("00.100p+004")>]
+[<InlineData("00.0100p+008")>]
+[<InlineData("0010.0p-004")>]
+[<InlineData("0x1.0p0")>]
+[<InlineData("0X1.0P0")>]
+[<InlineData("0x001.00p+000")>]
+[<InlineData("0x00.100p+004")>]
+[<InlineData("0x.100p+004")>]
+[<InlineData("0x0010.0p-004")>]
+[<InlineData("+001")>]
+[<InlineData("+1.")>]
+[<InlineData("+1.0")>]
+[<InlineData("+.100p+004")>]
+[<InlineData("+0x0010.0p-004")>]
+let ``floatOfHexString handles different formats of 1.0`` str =
+    Assert.Equal(1.0f, float32OfHexString str)
+
+[<Theory>]
+[<InlineData("-001")>]
+[<InlineData("-1.")>]
+[<InlineData("-1.0")>]
+[<InlineData("-0x1")>]
+[<InlineData("-0X1")>]
+[<InlineData("-0x0001")>]
+[<InlineData("-0x1.")>]
+[<InlineData("-0x1.0")>]
+[<InlineData("-0x001.0")>]
+[<InlineData("-1.0p0")>]
+[<InlineData("-1.0P0")>]
+[<InlineData("-001.00p+000")>]
+[<InlineData("-.100p+004")>]
+[<InlineData("-.0100p+008")>]
+[<InlineData("-00.100p+004")>]
+[<InlineData("-00.0100p+008")>]
+[<InlineData("-0010.0p-004")>]
+[<InlineData("-0x1.0p0")>]
+[<InlineData("-0X1.0P0")>]
+[<InlineData("-0x001.00p+000")>]
+[<InlineData("-0x00.100p+004")>]
+[<InlineData("-0x.100p+004")>]
+[<InlineData("-0x0010.0p-004")>]
+let ``floatOfHexString handles different formats of -1.0`` str =
+    Assert.Equal(-1.0f, float32OfHexString str)
+
+[<Theory>]
+[<InlineData("0")>]
+[<InlineData("0.")>]
+[<InlineData("0.0")>]
+[<InlineData("00.0")>]
+[<InlineData("00.000")>]
+[<InlineData("00.000p0")>]
+[<InlineData("00.000p99999999")>]
+[<InlineData("0x0")>]
+[<InlineData("0x0.")>]
+[<InlineData("0x0.0")>]
+[<InlineData("0x00.0")>]
+[<InlineData("0x00.000")>]
+[<InlineData("0x00.000p0")>]
+[<InlineData("0x00.000p99999999")>]
+[<InlineData("100P-2147483639")>]
+[<InlineData("100P-2147483640")>]
+[<InlineData("100P-2147483647")>]
+[<InlineData("100P-9999999999999999999999999")>]
+[<InlineData("0.001P-2147483639")>]
+[<InlineData("0.001P-2147483640")>]
+[<InlineData("0.001P-2147483647")>]
+[<InlineData("0.001P-9999999999999999999999999")>]
+let ``floatOfHexString generates floats that are binary equivalent to positive 0`` str =
+    let actual = float32OfHexString str
+    Assert.Equal(BitConverter.SingleToInt32Bits(0.0f), BitConverter.SingleToInt32Bits(actual))
+
+[<Theory>]
+[<InlineData("-0")>]
+[<InlineData("-0.")>]
+[<InlineData("-0.0")>]
+[<InlineData("-00.0")>]
+[<InlineData("-00.000")>]
+[<InlineData("-00.000p0")>]
+[<InlineData("-00.000p99999999")>]
+[<InlineData("-0x0")>]
+[<InlineData("-0x0.")>]
+[<InlineData("-0x0.0")>]
+[<InlineData("-0x00.0")>]
+[<InlineData("-0x00.000")>]
+[<InlineData("-0x00.000p0")>]
+[<InlineData("-0x00.000p0")>]
+[<InlineData("-0x00.000p99999999")>]
+[<InlineData("-100P-2147483639")>]
+[<InlineData("-100P-2147483640")>]
+[<InlineData("-100P-2147483647")>]
+[<InlineData("-100P-9999999999999999999999999")>]
+[<InlineData("-0.001P-2147483639")>]
+[<InlineData("-0.001P-2147483640")>]
+[<InlineData("-0.001P-2147483647")>]
+[<InlineData("-0.001P-9999999999999999999999999")>]
+let ``floatOfHexString generates floats that are binary equivalent to negative 0`` str =
+    let actual = float32OfHexString str
+    Assert.Equal(BitConverter.SingleToInt32Bits(-0.0f), BitConverter.SingleToInt32Bits(actual))
+
+[<Theory>]
+[<InlineData("0x0123", 0x0123)>]
+[<InlineData("0x4567", 0x4567)>]
+[<InlineData("0x89ab", 0x89ab)>]
+[<InlineData("0x89AB", 0x89ab)>]
+[<InlineData("0xcdef", 0xcdef)>]
+[<InlineData("0xCDEF", 0xcdef)>]
+let ``Not sure what's being tested here`` str expected =
+    let actual = float32OfHexString str
+    Assert.Equal(single expected, actual)
+
+[<Theory>]
+[<InlineData("0x123.456e00p-8")>]
+[<InlineData("0x91.a2b700p-7")>]
+[<InlineData("0x48.d15b80p-6")>]
+[<InlineData("0x24.68adc0p-5")>]
+[<InlineData("0x12.3456e0p-4")>]
+[<InlineData("0x9.1a2b70p-3")>]
+[<InlineData("0x4.8d15b8p-2")>]
+[<InlineData("0x2.468adcp-1")>]
+[<InlineData("0x.91a2b70p+1")>]
+[<InlineData("0x.48d15b8p+2")>]
+[<InlineData("0x.2468adcp+3")>]
+[<InlineData("0x.123456ep+4")>]
+[<InlineData("0x.091a2b70p+5")>]
+[<InlineData("0x.048d15b8p+6")>]
+[<InlineData("0x.02468adcp+7")>]
+[<InlineData("0x.0123456ep+8")>]
+let ``Not sure what's being tested here also`` str =
+    let expected = float32OfHexString "0x1.23456e"
+    let actual = float32OfHexString str
+    
+    Assert.Equal(expected, actual)
+
+[<Theory>]
+[<InlineData("0x1.fffffep127")>]
+[<InlineData("0x.1fffffep131")>]
+[<InlineData("0x.01fffffep135")>]
+[<InlineData("0x1f.ffffep123")>]
+[<InlineData("0x1fffffe.p103")>]
+[<InlineData("0x0.ffffff5p128")>]
+[<InlineData("0x0.ffffff6p128")>]
+[<InlineData("0x0.ffffff7p128")>]
+[<InlineData("0x0.ffffff7ffffffffp128")>]
+let ``floatOfHexString generates max value floats for positive values near max value`` str =
+    let actual = float32OfHexString str
+    Assert.Equal(Single.MaxValue, actual)
+
+[<Theory>]
+[<InlineData("-0x1fffffe000.p91")>]
+let ``floatOfHexString generates max value floats for negative values near max value`` str =
+    let actual = float32OfHexString str
+    Assert.Equal(-Single.MaxValue, actual)
+
+[<Theory>]
+[<InlineData("0x0.ffffff8p128")>]
+[<InlineData("0x0.ffffff800000p128")>]
+[<InlineData("0x0.fffffffp128")>]
+[<InlineData("0x1p128")>]
+[<InlineData("100P2147483639")>]
+[<InlineData("100P2147483640")>]
+[<InlineData("100P2147483647")>]
+[<InlineData("100P9999999999999999999999999")>]
+[<InlineData("0.001P2147483639")>]
+[<InlineData("0.001P2147483640")>]
+[<InlineData("0.001P2147483647")>]
+[<InlineData("0.001P9999999999999999999999999")>]
+let ``floatOfHexString throws a System Overflow exception when passed values that are too large`` str =
+    Assert.Throws<OverflowException>(fun () -> float32OfHexString str |> ignore)
+
+[<Theory>]
+[<InlineData("0x1.000001e")>]
+[<InlineData("0x1.000001c")>]
+[<InlineData("0x1.000001a")>]
+[<InlineData("0x1.0000018")>]
+[<InlineData("0x2.0000024p-1")>]
+[<InlineData("0x4.0000048p-2")>]
+[<InlineData("0x8.0000090p-3")>]
+[<InlineData("0x1.0000016")>]
+[<InlineData("0x1.0000014")>]
+[<InlineData("0x2.0000028p-1")>]
+[<InlineData("0x4.0000050p-2")>]
+[<InlineData("0x8.00000a0p-3")>]
+[<InlineData("0x1.0000012")>]
+[<InlineData("0x2.0000024p-1")>]
+[<InlineData("0x4.0000048p-2")>]
+[<InlineData("0x8.0000090p-3")>]
+[<InlineData("0x1.00000110")>]
+[<InlineData("0x2.00000220p-1")>]
+[<InlineData("0x4.00000440p-2")>]
+[<InlineData("0x8.00000880p-3")>]
+[<InlineData("0x1.00000108")>]
+[<InlineData("0x2.00000210p-1")>]
+[<InlineData("0x4.00000420p-2")>]
+[<InlineData("0x8.00000840p-3")>]
+[<InlineData("0x1.00000104")>]
+[<InlineData("0x2.00000208p-1")>]
+[<InlineData("0x4.0000041p-2")>]
+[<InlineData("0x8.0000082p-3")>]
+let ``floatOfHexString handles values near 1`` str =
+    let expected = 1.0f + 2.0f*eps
+    
+    let actual = float32OfHexString str
+    
+    Assert.Equal(expected, actual)
+
+let nearestValueData : obj[] list =
+    [
+        [|"0x1.000001" ; 1.f |]
+        [|"0x2.000002p-1" ; 1.f |]
+        [|"0x4.000004p-2" ; 1.f |]
+        [|"0x8.00000p-3" ; 1.f |]
+        [|"0x1.00000100000010000"; 1.f + 2.f*eps |]
+        [|"0x1.000000ffffffffff"; 1.f |]
+        [|"0x1.000000e"; 1.f |]
+        [|"0x1.000000c"; 1.f |]
+        [|"0x1.000000a"; 1.f |]
+        [|"0x1.0000008"; 1.f |]
+        [|"0x1.0000006"; 1.f |]
+        [|"0x1.0000004"; 1.f |]
+        [|"0x1.0000002"; 1.f |]
+        [|"0x1.0000000"; 1.f |]
+        [|"0x1.fffffffffP-1"; 1.f |]
+        [|"0x1.ffffffeP-1"; 1.f |]
+        [|"0x1.ffffffcP-1"; 1.f |]
+        [|"0x1.ffffffaP-1"; 1.f |]
+        [|"0x1.ffffff8P-1"; 1.f |]
+        [|"0x1.ffffff6P-1"; 1.f |]
+        [|"0x1.ffffff4P-1"; 1.f |]
+        [|"0x1.ffffff2P-1"; 1.f |]
+        [|"0x1.ffffffP-1"; 1.f |] // round towards even
+        [|"0x1.ffffff0000P-1"; 1.f |]
+        [|"0x1.fffffefffffP-1"; 1.f - eps |]
+        [|"0x1.fffffee0001P-1"; 1.f - eps |]
+        [|"0x1.fffffecP-1"; 1.f - eps |]
+        [|"0x1.fffffeaP-1"; 1.f - eps |]
+        [|"0x1.fffffe8P-1"; 1.f - eps |]
+        [|"0x1.fffffe6P-1"; 1.f - eps |]
+        [|"0x1.fffffe4P-1"; 1.f - eps |]
+        [|"0x1.fffffe2P-1"; 1.f - eps |]
+        [|"0x1.fffffe0P-1"; 1.f - eps |]
+        [|"0x1.fffffd001P-1"; 1.f - eps |]
+        [|"0x0.8000008P-125"; min |]
+        [|"0x0.80000080P-125"; min |]
+        [|"0x0.8000007ffffP-125"; min |]
+        [|"0x0.8000007P-125"; min |]
+        [|"0x0.8000006P-125"; min |]
+        [|"0x0.8000005P-125"; min |]
+        [|"0x0.8000004P-125"; min |]
+        [|"0x0.8000003P-125"; min |]
+        [|"0x0.8000002P-125"; min |]
+        [|"0x0.8000001P-125"; min |]
+        [|"0x0.8000000P-125"; min |]
+        [|"0x0.7ffffffP-125"; min |]
+        [|"0x0.7fffffeP-125"; min |]
+        [|"0x0.7fffffdP-125"; min |]
+        [|"0x0.7fffffcP-125"; min |]
+        [|"0x0.7fffffbP-125"; min |]
+        [|"0x0.7fffffaP-125"; min |]
+        [|"0x0.7fffff9P-125"; min |]
+        [|"0x0.7fffff8P-125"; min |]
+        [|"0x0.7fffff7fffP-125"; min - minmin |]
+        [|"0x0.7fffff7P-125"; min - minmin |]
+        [|"0x0.7fffff6P-125"; min - minmin |]
+        [|"0x0.7fffff5P-125"; min - minmin |]
+        [|"0x0.7fffff4P-125"; min - minmin |]
+        [|"0x0.7fffff3P-125"; min - minmin |]
+        [|"0x0.7fffff2P-125"; min - minmin |]
+        [|"0x0.7fffff1P-125"; min - minmin |]
+        [|"0x0.7fffff0P-125"; min - minmin |]
+        [|"0x0.7ffffefP-125"; min - minmin |]
+        [|"0x0.7ffffeeP-125"; min - minmin |]
+        [|"0x0.7ffffedP-125"; min - minmin |]
+        [|"0x0.7ffffecP-125"; min - minmin |]
+        [|"0x0.7ffffebP-125"; min - minmin |]
+        [|"0x0.7ffffeaP-125"; min - minmin |]
+        [|"0x0.7ffffe9P-125"; min - minmin |]
+        [|"0x0.7ffffe8001P-125"; min - minmin |]
+        [|"0x0.7ffffe8P-125"; min - 2.f*minmin |]
+        [|"0x0.7ffffe80P-125"; min - 2.f*minmin |]
+        [|"0x0.7ffffe7ffP-125"; min - 2.f*minmin |]
+        [|"0x0.0000019P-125"; 2.f*minmin |]
+        [|"0x0.0000018P-125"; 2.f*minmin |]
+        [|"0x0.0000017ffP-125"; minmin |]
+        [|"0x0.000001P-125"; minmin |]
+        [|"0x0.0000010P-125"; minmin |]
+        [|"0x0.0000008001P-125"; minmin |]
+        [|"0x0.0000008P-125"; 0.f |]
+        [|"0x0.0000007ffffP-125"; 0.f |]
+        [|"0x1P-150"; 0.f |]
+    ]
+
+[<Theory>]
+[<MemberData(nameof(nearestValueData))>]
+let ``floatOfHexString rounds to the nearest even value`` str expected =
+    let actual = float32OfHexString str
+    
+    Assert.Equal(expected, actual)
+
+let zeroValueData : obj[] list =
+    [
+        [|"0x1.fffffdP-1"   ; 1.f - 2.f*eps |] // round towards zero
+        [|"0x1.fffffd0P-1"  ; 1.f - 2.f*eps |]
+        [|"0x1.fffffcfffP-1"; 1.f - 2.f*eps |]
+        [|"0x1.fffffce0P-1" ; 1.f - 2.f*eps |]
+        [|"0x1.fffffc20P-1" ; 1.f - 2.f*eps |]
+        [|"0x0.800000fP-125"; min + minmin |]
+        [|"0x0.800000eP-125"; min + minmin |]
+        [|"0x0.800000dP-125"; min + minmin |]
+        [|"0x0.800000cP-125"; min + minmin |]
+        [|"0x0.800000bP-125"; min + minmin |]
+        [|"0x0.800000aP-125"; min + minmin |]
+        [|"0x0.8000009P-125"; min + minmin |]
+        [|"0x0.8000008001P-125"; min + minmin |]
+    ]
+
+[<Theory>]
+[<MemberData(nameof(zeroValueData))>]
+let ``floatOfHexString rounds towards zero value`` str expected =
+    let actual = float32OfHexString str
+    
+    Assert.Equal(expected, actual)

--- a/Test/HexFloatTests.fs
+++ b/Test/HexFloatTests.fs
@@ -6,13 +6,14 @@ module FParsec.Test.HexFloatTests
 open System
 open Microsoft.FSharp.Core
 open Xunit
-open FParsec.Test.Test
 
 let floatToHexString   = FParsec.CharParsers.floatToHexString
 let floatOfHexString   = FParsec.CharParsers.floatOfHexString
-let float32ToHexString = FParsec.CharParsers.float32ToHexString
-let float32OfHexString = FParsec.CharParsers.float32OfHexString
-    
+let eps    = Math.Pow(2.0, -53.0)
+let min    = Math.Pow(2.0, -1022.0)  // smallest normal number
+let minmin = Math.Pow(2.0, -1074.0) // smallest subnormal number
+
+
 [<FParsecProperty(MaxTest = 100000)>]
 let ``floatToHexString output matches test oracle implementation`` (f: float) =
     floatToHexString f === Float.toHexString f
@@ -103,728 +104,328 @@ let ``floatOfHexString correctly handles Infinity and NaN strings`` str expected
     Assert.Equal(expected, floatOfHexString str)
 
 [<Theory>]
-[<InlineData("001", 1L)>]
-[<InlineData("1.", 1L)>]
-[<InlineData("1.0", 1L)>]
-[<InlineData("0x1", 1L)>]
-[<InlineData("0X1", 1L)>]
-[<InlineData("0x0001", 1L)>]
-[<InlineData("0x1.", 1L)>]
-[<InlineData("0x1.0", 1L)>]
-[<InlineData("0x001.0", 1L)>]
-[<InlineData("1.0p0", 1L)>]
-[<InlineData("1.0P0", 1L)>]
-[<InlineData("001.00p+000", 1L)>]
-[<InlineData(".100p+004", 1L)>]
-[<InlineData(".0100p+008", 1L)>]
-[<InlineData("00.100p+004", 1L)>]
-[<InlineData("00.0100p+008", 1L)>]
-[<InlineData("0010.0p-004", 1L)>]
-[<InlineData("0x1.0p0", 1L)>]
-[<InlineData("0X1.0P0", 1L)>]
-[<InlineData("0x001.00p+000", 1L)>]
-[<InlineData("0x00.100p+004", 1L)>]
-[<InlineData("0x.100p+004", 1L)>]
-[<InlineData("0x0010.0p-004", 1L)>]
-[<InlineData("+001", 1L)>]
-[<InlineData("+1.", 1L)>]
-[<InlineData("+1.0", 1L)>]
-[<InlineData("+.100p+004", 1L)>]
-[<InlineData("+0x0010.0p-004", 1L)>]
-let ``floatOfHexString handles different formats of 1.0`` str expected =
-    Assert.Equal(expected, floatOfHexString str)
+[<InlineData("001")>]
+[<InlineData("1.")>]
+[<InlineData("1.0")>]
+[<InlineData("0x1")>]
+[<InlineData("0X1")>]
+[<InlineData("0x0001")>]
+[<InlineData("0x1.")>]
+[<InlineData("0x1.0")>]
+[<InlineData("0x001.0")>]
+[<InlineData("1.0p0")>]
+[<InlineData("1.0P0")>]
+[<InlineData("001.00p+000")>]
+[<InlineData(".100p+004")>]
+[<InlineData(".0100p+008")>]
+[<InlineData("00.100p+004")>]
+[<InlineData("00.0100p+008")>]
+[<InlineData("0010.0p-004")>]
+[<InlineData("0x1.0p0")>]
+[<InlineData("0X1.0P0")>]
+[<InlineData("0x001.00p+000")>]
+[<InlineData("0x00.100p+004")>]
+[<InlineData("0x.100p+004")>]
+[<InlineData("0x0010.0p-004")>]
+[<InlineData("+001")>]
+[<InlineData("+1.")>]
+[<InlineData("+1.0")>]
+[<InlineData("+.100p+004")>]
+[<InlineData("+0x0010.0p-004")>]
+let ``floatOfHexString handles different formats of 1.0`` str =
+    Assert.Equal(1.0, floatOfHexString str)
 
 [<Theory>]
-[<InlineData("-001", -1L)>]
-[<InlineData("-1.", -1L)>]
-[<InlineData("-1.0", -1L)>]
-[<InlineData("-0x1", -1L)>]
-[<InlineData("-0X1", -1L)>]
-[<InlineData("-0x0001", -1L)>]
-[<InlineData("-0x1.", -1L)>]
-[<InlineData("-0x1.0", -1L)>]
-[<InlineData("-0x001.0", -1L)>]
-[<InlineData("-1.0p0", -1L)>]
-[<InlineData("-1.0P0", -1L)>]
-[<InlineData("-001.00p+000", -1L)>]
-[<InlineData("-.100p+004", -1L)>]
-[<InlineData("-.0100p+008", -1L)>]
-[<InlineData("-00.100p+004", -1L)>]
-[<InlineData("-00.0100p+008", -1L)>]
-[<InlineData("-0010.0p-004", -1L)>]
-[<InlineData("-0x1.0p0", -1L)>]
-[<InlineData("-0X1.0P0", -1L)>]
-[<InlineData("-0x001.00p+000", -1L)>]
-[<InlineData("-0x00.100p+004", -1L)>]
-[<InlineData("-0x.100p+004", -1L)>]
-[<InlineData("-0x0010.0p-004", -1L)>]
-let ``floatOfHexString handles different formats of -1.0`` str expected =
-    Assert.Equal(expected, floatOfHexString str)
+[<InlineData("-001")>]
+[<InlineData("-1.")>]
+[<InlineData("-1.0")>]
+[<InlineData("-0x1")>]
+[<InlineData("-0X1")>]
+[<InlineData("-0x0001")>]
+[<InlineData("-0x1.")>]
+[<InlineData("-0x1.0")>]
+[<InlineData("-0x001.0")>]
+[<InlineData("-1.0p0")>]
+[<InlineData("-1.0P0")>]
+[<InlineData("-001.00p+000")>]
+[<InlineData("-.100p+004")>]
+[<InlineData("-.0100p+008")>]
+[<InlineData("-00.100p+004")>]
+[<InlineData("-00.0100p+008")>]
+[<InlineData("-0010.0p-004")>]
+[<InlineData("-0x1.0p0")>]
+[<InlineData("-0X1.0P0")>]
+[<InlineData("-0x001.00p+000")>]
+[<InlineData("-0x00.100p+004")>]
+[<InlineData("-0x.100p+004")>]
+[<InlineData("-0x0010.0p-004")>]
+let ``floatOfHexString handles different formats of -1.0`` str =
+    Assert.Equal(-1.0, floatOfHexString str)
 
 [<Theory>]
-[<InlineData("0", 0L)>]
-[<InlineData("0.", 0L)>]
-[<InlineData("0.0", 0L)>]
-[<InlineData("00.0", 0L)>]
-[<InlineData("00.000", 0L)>]
-[<InlineData("00.000p0", 0L)>]
-[<InlineData("00.000p99999999", 0L)>]
-[<InlineData("0x0", 0L)>]
-[<InlineData("0x0.", 0L)>]
-[<InlineData("0x0.0", 0L)>]
-[<InlineData("0x00.0", 0L)>]
-[<InlineData("0x00.000", 0L)>]
-[<InlineData("0x00.000p0", 0L)>]
-[<InlineData("0x00.000p99999999", 0L)>]
-[<InlineData("100P-2147483639", 0L)>]
-[<InlineData("100P-2147483640", 0L)>]
-[<InlineData("100P-2147483647", 0L)>]
-[<InlineData("100P-9999999999999999999999999", 0L)>]
-[<InlineData("0.001P-2147483639", 0L)>]
-[<InlineData("0.001P-2147483640", 0L)>]
-[<InlineData("0.001P-2147483647", 0L)>]
-[<InlineData("0.001P-9999999999999999999999999", 0L)>]
-let ``floatOfHexString generates floats that are binary equivalent to 0`` str expected =
+[<InlineData("0")>]
+[<InlineData("0.")>]
+[<InlineData("0.0")>]
+[<InlineData("00.0")>]
+[<InlineData("00.000")>]
+[<InlineData("00.000p0")>]
+[<InlineData("00.000p99999999")>]
+[<InlineData("0x0")>]
+[<InlineData("0x0.")>]
+[<InlineData("0x0.0")>]
+[<InlineData("0x00.0")>]
+[<InlineData("0x00.000")>]
+[<InlineData("0x00.000p0")>]
+[<InlineData("0x00.000p99999999")>]
+[<InlineData("100P-2147483639")>]
+[<InlineData("100P-2147483640")>]
+[<InlineData("100P-2147483647")>]
+[<InlineData("100P-9999999999999999999999999")>]
+[<InlineData("0.001P-2147483639")>]
+[<InlineData("0.001P-2147483640")>]
+[<InlineData("0.001P-2147483647")>]
+[<InlineData("0.001P-9999999999999999999999999")>]
+let ``floatOfHexString generates floats that are binary equivalent to positive 0`` str =
     let actual = floatOfHexString str
-    Assert.Equal(BitConverter.DoubleToInt64Bits(expected), BitConverter.DoubleToInt64Bits(actual))
-
-
-let testDoubleHexFloat() =
-    /// bitwise equal
-    let BEqual a b =
-        Equal (System.BitConverter.DoubleToInt64Bits(a)) (System.BitConverter.DoubleToInt64Bits(b))
-
-    // float32ToHexString
-    ///////////////////
-
-    let max    = Double.MaxValue
-    let eps    = Math.Pow(2.0, -53.0)
-    let min    = Math.Pow(2.0, -1022.0)  // smallest normal number
-    let minmin = Math.Pow(2.0, -1074.0) // smallest subnormal number
-
-
-
-
-    // floatOfHexString
-    ///////////////////
-
-    floatOfHexString "-0"        |> BEqual -0.0
-    floatOfHexString "-0."       |> BEqual -0.0
-    floatOfHexString "-0.0"      |> BEqual -0.0
-    floatOfHexString "-00.0"     |> BEqual -0.0
-    floatOfHexString "-00.000"   |> BEqual -0.0
-    floatOfHexString "-00.000p0" |> BEqual -0.
-    floatOfHexString "-00.000p99999999" |> BEqual -0.
-    floatOfHexString "-0x0"        |> BEqual -0.0
-    floatOfHexString "-0x0."       |> BEqual -0.0
-    floatOfHexString "-0x0.0"      |> BEqual -0.0
-    floatOfHexString "-0x00.0"     |> BEqual -0.0
-    floatOfHexString "-0x00.000"   |> BEqual -0.0
-    floatOfHexString "-0x00.000p0" |> BEqual -0.0
-    floatOfHexString "-0x00.000p0" |> BEqual -0.
-    floatOfHexString "-0x00.000p99999999" |> BEqual -0.
-    floatOfHexString "-100P-2147483639"   |> BEqual -0.
-    floatOfHexString "-100P-2147483640"   |> BEqual -0.
-    floatOfHexString "-100P-2147483647"   |> BEqual -0.
-    floatOfHexString "-100P-9999999999999999999999999"   |> BEqual -0.
-    floatOfHexString "-0.001P-2147483639" |> BEqual -0.
-    floatOfHexString "-0.001P-2147483640" |> BEqual -0.
-    floatOfHexString "-0.001P-2147483647" |> BEqual -0.
-    floatOfHexString "-0.001P-9999999999999999999999999" |> BEqual -0.
-
-    floatOfHexString "0x0123" |> Equal (double 0x0123)
-    floatOfHexString "0x4567" |> Equal (double 0x4567)
-    floatOfHexString "0x89ab" |> Equal (double 0x89ab)
-    floatOfHexString "0x89AB" |> Equal (double 0x89ab)
-    floatOfHexString "0xcdef" |> Equal (double 0xcdef)
-    floatOfHexString "0xCDEF" |> Equal (double 0xcdef)
-
-    let v = floatOfHexString "0x1.23456789abcde"
-
-    floatOfHexString "0x123.456789abcde00p-8" |> Equal v
-    floatOfHexString "0x91.a2b3c4d5e6f00p-7" |> Equal v
-    floatOfHexString "0x48.d159e26af3780p-6" |> Equal v
-    floatOfHexString "0x24.68acf13579bc0p-5" |> Equal v
-    floatOfHexString "0x12.3456789abcde0p-4" |> Equal v
-    floatOfHexString "0x9.1a2b3c4d5e6fp-3" |> Equal v
-    floatOfHexString "0x4.8d159e26af378p-2" |> Equal v
-    floatOfHexString "0x2.468acf13579bcp-1" |> Equal v
-    floatOfHexString "0x.91a2b3c4d5e6f0p+1" |> Equal v
-    floatOfHexString "0x.48d159e26af378p+2" |> Equal v
-    floatOfHexString "0x.2468acf13579bcp+3" |> Equal v
-    floatOfHexString "0x.123456789abcdep+4" |> Equal v
-    floatOfHexString "0x.091a2b3c4d5e6f0p+5" |> Equal v
-    floatOfHexString "0x.048d159e26af378p+6" |> Equal v
-    floatOfHexString "0x.02468acf13579bcp+7" |> Equal v
-    floatOfHexString "0x.0123456789abcdep+8" |> Equal v
-
-    // near max
-    floatOfHexString "0x1.fffffffffffffp1023"  |> Equal max
-    floatOfHexString "0x.1fffffffffffffp1027"  |> Equal max
-    floatOfHexString "0x.01fffffffffffffp1031" |> Equal max
-    floatOfHexString "0x1f.ffffffffffffp1019" |> Equal max
-    floatOfHexString "0x1fffffffffffff.p971" |> Equal max
-    floatOfHexString "-0x1fffffffffffff000.p959" |> Equal (-max)
-
-    floatOfHexString "0x1.fffffffffffff5p1023"  |> Equal max
-    floatOfHexString "0x1.fffffffffffff6p1023"  |> Equal max
-    floatOfHexString "0x1.fffffffffffff7p1023"  |> Equal max
-    floatOfHexString "0x1.fffffffffffff7ffffffffp1023"  |> Equal max
-
-    let checkOverflow s =
-        try floatOfHexString s |> ignore; Fail ()
-        with :? System.OverflowException -> ()
-
-    checkOverflow "0x1.fffffffffffff8p1023"
-    checkOverflow "0x1.fffffffffffff800000p1023"
-    checkOverflow "0x1.ffffffffffffffp1023"
-    checkOverflow "0x1p1024"
-    checkOverflow "100P2147483639"
-    checkOverflow "100P2147483640"
-    checkOverflow "100P2147483647"
-    checkOverflow "100P9999999999999999999999999"
-    checkOverflow "0.001P2147483639"
-    checkOverflow "0.001P2147483640"
-    checkOverflow "0.001P2147483647"
-    checkOverflow "0.001P9999999999999999999999999"
-
-    // near 1
-    floatOfHexString "0x1.0000000000000f" |> Equal (1.0 + 2.*eps)
-    floatOfHexString "0x1.0000000000000e" |> Equal (1.0 + 2.*eps)
-    floatOfHexString "0x1.0000000000000d" |> Equal (1.0 + 2.*eps)
-
-    floatOfHexString "0x1.0000000000000c" |> Equal (1.0 + 2.*eps)
-    floatOfHexString "0x2.00000000000018p-1" |> Equal (1.0 + 2.*eps)
-    floatOfHexString "0x4.0000000000003p-2"  |> Equal (1.0 + 2.*eps)
-    floatOfHexString "0x8.0000000000006p-3"  |> Equal (1.0 + 2.*eps)
-
-    floatOfHexString "0x1.0000000000000b" |> Equal (1.0 + 2.*eps)
-
-    floatOfHexString "0x1.0000000000000a" |> Equal (1.0 + 2.*eps)
-    floatOfHexString "0x2.00000000000014p-1" |> Equal (1.0 + 2.*eps)
-    floatOfHexString "0x4.00000000000028p-2" |> Equal (1.0 + 2.*eps)
-    floatOfHexString "0x8.0000000000005p-3"  |> Equal (1.0 + 2.*eps)
-
-    floatOfHexString "0x1.00000000000009"   |> Equal (1.0 + 2.*eps)
-    floatOfHexString "0x2.00000000000012p-1"  |> Equal (1.0 + 2.*eps)
-    floatOfHexString "0x4.00000000000024p-2"  |> Equal (1.0 + 2.*eps)
-    floatOfHexString "0x8.00000000000048p-3" |> Equal (1.0 + 2.*eps)
-
-    floatOfHexString "0x1.000000000000088"    |> Equal (1.0 + 2.*eps)
-    floatOfHexString "0x2.00000000000011p-1"  |> Equal (1.0 + 2.*eps)
-    floatOfHexString "0x4.00000000000022p-2"  |> Equal (1.0 + 2.*eps)
-    floatOfHexString "0x8.00000000000044p-3"  |> Equal (1.0 + 2.*eps)
-
-    floatOfHexString "0x1.000000000000084"    |> Equal (1.0 + 2.*eps)
-    floatOfHexString "0x2.000000000000108p-1"  |> Equal (1.0 + 2.*eps)
-    floatOfHexString "0x4.00000000000021p-2"  |> Equal (1.0 + 2.*eps)
-    floatOfHexString "0x8.00000000000042p-3"  |> Equal (1.0 + 2.*eps)
-
-    floatOfHexString "0x1.000000000000082"    |> Equal (1.0 + 2.*eps)
-    floatOfHexString "0x2.000000000000104p-1"  |> Equal (1.0 + 2.*eps)
-    floatOfHexString "0x4.000000000000208p-2"  |> Equal (1.0 + 2.*eps)
-    floatOfHexString "0x8.00000000000041p-3"  |> Equal (1.0 + 2.*eps)
-
-    floatOfHexString "0x1.00000000000008"    |> Equal (1.0)  // round towards even
-    floatOfHexString "0x2.0000000000001p-1"  |> Equal (1.0)
-    floatOfHexString "0x4.0000000000002p-2"  |> Equal (1.0)
-    floatOfHexString "0x8.0000000000004p-3"  |> Equal (1.0)
-
-    floatOfHexString "0x1.0000000000000800000010000" |> Equal (1.0 + 2.*eps)
-    floatOfHexString "0x1.00000000000007ffffffffff" |> Equal (1.0)
-    floatOfHexString "0x1.00000000000007" |> Equal (1.0)
-    floatOfHexString "0x1.00000000000006" |> Equal (1.0)
-    floatOfHexString "0x1.00000000000005" |> Equal (1.0)
-    floatOfHexString "0x1.00000000000004" |> Equal (1.0)
-    floatOfHexString "0x1.00000000000003" |> Equal (1.0)
-    floatOfHexString "0x1.00000000000002" |> Equal (1.0)
-    floatOfHexString "0x1.00000000000001" |> Equal (1.0)
-    floatOfHexString "0x1.00000000000000" |> Equal (1.0)
-    floatOfHexString "0x1.ffffffffffffffffP-1" |> Equal (1.0)
-    floatOfHexString "0x1.fffffffffffffeP-1" |> Equal (1.0)
-    floatOfHexString "0x1.fffffffffffffdP-1" |> Equal (1.0)
-    floatOfHexString "0x1.fffffffffffffcP-1" |> Equal (1.0)
-    floatOfHexString "0x1.fffffffffffffbP-1" |> Equal (1.0)
-    floatOfHexString "0x1.fffffffffffffaP-1" |> Equal (1.0)
-    floatOfHexString "0x1.fffffffffffff9P-1" |> Equal (1.0)
-    floatOfHexString "0x1.fffffffffffff8P-1" |> Equal (1.0) // round towards even
-    floatOfHexString "0x1.fffffffffffff800P-1" |> Equal (1.0)
-    floatOfHexString "0x1.fffffffffffff7ffffffP-1" |> Equal (1.0 - eps)
-    floatOfHexString "0x1.fffffffffffff7000001P-1" |> Equal (1.0 - eps)
-    floatOfHexString "0x1.fffffffffffff7P-1" |> Equal (1.0 - eps)
-    floatOfHexString "0x1.fffffffffffff6P-1" |> Equal (1.0 - eps)
-    floatOfHexString "0x1.fffffffffffff5P-1" |> Equal (1.0 - eps)
-    floatOfHexString "0x1.fffffffffffff4P-1" |> Equal (1.0 - eps)
-    floatOfHexString "0x1.fffffffffffff3P-1" |> Equal (1.0 - eps)
-    floatOfHexString "0x1.fffffffffffff2P-1" |> Equal (1.0 - eps)
-    floatOfHexString "0x1.fffffffffffff1P-1" |> Equal (1.0 - eps)
-    floatOfHexString "0x1.fffffffffffff0P-1" |> Equal (1.0 - eps)
-    floatOfHexString "0x1.ffffffffffffefP-1" |> Equal (1.0 - eps)
-    floatOfHexString "0x1.ffffffffffffe8001P-1" |> Equal (1.0 - eps)
-    floatOfHexString "0x1.ffffffffffffe8P-1" |> Equal (1.0 - 2.*eps) // round towards even
-    floatOfHexString "0x1.ffffffffffffe80P-1" |> Equal (1.0 - 2.*eps)
-    floatOfHexString "0x1.ffffffffffffe7ffffP-1" |> Equal (1.0 - 2.*eps)
-    floatOfHexString "0x1.ffffffffffffe70P-1" |> Equal (1.0 - 2.*eps)
-    floatOfHexString "0x1.ffffffffffffe1P-1" |> Equal (1.0 - 2.*eps)
-
-    floatOfHexString "0x1.0000000000000fP-1022" |> Equal (min + minmin)
-    floatOfHexString "0x1.0000000000000eP-1022" |> Equal (min + minmin)
-    floatOfHexString "0x1.0000000000000dP-1022" |> Equal (min + minmin)
-    floatOfHexString "0x1.0000000000000cP-1022" |> Equal (min + minmin)
-    floatOfHexString "0x1.0000000000000bP-1022" |> Equal (min + minmin)
-    floatOfHexString "0x1.0000000000000aP-1022" |> Equal (min + minmin)
-    floatOfHexString "0x1.00000000000009P-1022" |> Equal (min + minmin)
-    floatOfHexString "0x1.00000000000008001P-1022" |> Equal (min + minmin)
-    floatOfHexString "0x1.00000000000008P-1022" |> Equal (min) // round towards even
-    floatOfHexString "0x1.000000000000080P-1022" |> Equal (min)
-    floatOfHexString "0x1.00000000000007ffffP-1022" |> Equal (min)
-    floatOfHexString "0x1.00000000000007P-1022" |> Equal (min)
-    floatOfHexString "0x1.00000000000006P-1022" |> Equal (min)
-    floatOfHexString "0x1.00000000000005P-1022" |> Equal (min)
-    floatOfHexString "0x1.00000000000004P-1022" |> Equal (min)
-    floatOfHexString "0x1.00000000000003P-1022" |> Equal (min)
-    floatOfHexString "0x1.00000000000002P-1022" |> Equal (min)
-    floatOfHexString "0x1.00000000000001P-1022" |> Equal (min)
-    floatOfHexString "0x1.00000000000000P-1022" |> Equal (min)
-    floatOfHexString "0x0.ffffffffffffffP-1022" |> Equal (min)
-    floatOfHexString "0x0.fffffffffffffeP-1022" |> Equal (min)
-    floatOfHexString "0x0.fffffffffffffdP-1022" |> Equal (min)
-    floatOfHexString "0x0.fffffffffffffcP-1022" |> Equal (min)
-    floatOfHexString "0x0.fffffffffffffbP-1022" |> Equal (min)
-    floatOfHexString "0x0.fffffffffffffaP-1022" |> Equal (min)
-    floatOfHexString "0x0.fffffffffffff9P-1022" |> Equal (min)
-    floatOfHexString "0x0.fffffffffffff8P-1022" |> Equal (min) // round towards even
-    floatOfHexString "0x0.fffffffffffff7fffP-1022" |> Equal (min - minmin)
-    floatOfHexString "0x0.fffffffffffff7P-1022" |> Equal (min - minmin)
-    floatOfHexString "0x0.fffffffffffff6P-1022" |> Equal (min - minmin)
-    floatOfHexString "0x0.fffffffffffff5P-1022" |> Equal (min - minmin)
-    floatOfHexString "0x0.fffffffffffff4P-1022" |> Equal (min - minmin)
-    floatOfHexString "0x0.fffffffffffff3P-1022" |> Equal (min - minmin)
-    floatOfHexString "0x0.fffffffffffff2P-1022" |> Equal (min - minmin)
-    floatOfHexString "0x0.fffffffffffff1P-1022" |> Equal (min - minmin)
-    floatOfHexString "0x0.fffffffffffff0P-1022" |> Equal (min - minmin)
-    floatOfHexString "0x0.ffffffffffffefP-1022" |> Equal (min - minmin)
-    floatOfHexString "0x0.ffffffffffffeeP-1022" |> Equal (min - minmin)
-    floatOfHexString "0x0.ffffffffffffedP-1022" |> Equal (min - minmin)
-    floatOfHexString "0x0.ffffffffffffecP-1022" |> Equal (min - minmin)
-    floatOfHexString "0x0.ffffffffffffebP-1022" |> Equal (min - minmin)
-    floatOfHexString "0x0.ffffffffffffeaP-1022" |> Equal (min - minmin)
-    floatOfHexString "0x0.ffffffffffffe9P-1022" |> Equal (min - minmin)
-    floatOfHexString "0x0.ffffffffffffe8001P-1022" |> Equal (min - minmin)
-    floatOfHexString "0x0.ffffffffffffe8P-1022" |> Equal (min - 2.*minmin) // round towards even
-    floatOfHexString "0x0.ffffffffffffe80P-1022" |> Equal (min - 2.*minmin) // round towards even
-    floatOfHexString "0x0.ffffffffffffe7ffP-1022" |> Equal (min - 2.*minmin)
-
-    floatOfHexString "0x0.00000000000019P-1022" |> Equal (2.*minmin)
-    floatOfHexString "0x0.00000000000018P-1022" |> Equal (2.*minmin) // round towards even
-    floatOfHexString "0x0.00000000000017ffP-1022" |> Equal (minmin)
-    floatOfHexString "0x0.0000000000001P-1022" |> Equal (minmin)
-    floatOfHexString "0x0.00000000000010P-1022" |> Equal (minmin)
-    floatOfHexString "0x0.00000000000008001P-1022" |> Equal (minmin)
-    floatOfHexString "0x0.00000000000008P-1022" |> Equal (0.) // round towards even
-    floatOfHexString "0x0.00000000000007ffffP-1022" |> Equal (0.)
-    floatOfHexString "0x1.P-1075" |> Equal (0.)
-
-    // round trip checking
-    //////////////////////
-    let rand = System.Random(123)
-    let buffer = Array.zeroCreate 8
-    let randomFloat() =
-        rand.NextBytes(buffer)
-        System.BitConverter.ToDouble(buffer, 0)
-
-    for i = 0 to 100000 do
-        let f = randomFloat()
-        let s = floatToHexString f
-        let f2 = floatOfHexString s
-        True (f = f2 || f <> f)
-
-
-let testSingleHexFloat() =
-
-    /// bitwise equal
-    let BEqual (a: float32) (b: float32) =
-        Equal (System.BitConverter.GetBytes(a)) (System.BitConverter.GetBytes(b))
-
-
-    // float32ToHexString
-    ///////////////////
-
-    let max    = System.Single.MaxValue
-    let eps    = (float32) (System.Math.Pow(2.0, -24.0))
-    let min    = (float32) (System.Math.Pow(2.0, -126.0)) // smallest normal number
-    let minmin = (float32) (System.Math.Pow(2.0, -149.0)) // smallest subnormal number
-
-    float32ToHexString 0.0f |> Equal "0x0.0p0"
-    float32ToHexString -0.0f |> Equal "-0x0.0p0"
-    float32ToHexString 1.0f |> Equal "0x1.0p0"
-    float32ToHexString -1.0f |> Equal "-0x1.0p0"
-    float32ToHexString (1.0f + 4.f*eps) |> Equal "0x1.000004p0"
-    float32ToHexString (1.0f + 2.f*eps) |> Equal "0x1.000002p0"
-    float32ToHexString (1.0f - eps)     |> Equal "0x1.fffffep-1"
-    float32ToHexString (1.0f - 2.f*eps) |> Equal "0x1.fffffcp-1"
-    float32ToHexString min |> Equal "0x1.0p-126"
-    float32ToHexString (min + minmin)     |> Equal "0x1.000002p-126"
-    float32ToHexString (min - minmin)     |> Equal "0x0.fffffep-126"
-    float32ToHexString (min - 2.f*minmin) |> Equal "0x0.fffffcp-126"
-    float32ToHexString (minmin)           |> Equal "0x0.000002p-126"
-    float32ToHexString max |> Equal "0x1.fffffep127"
-
-    float32ToHexString System.Single.PositiveInfinity |> Equal "Infinity"
-    float32ToHexString System.Single.NegativeInfinity |> Equal "-Infinity"
-    float32ToHexString System.Single.NaN |> Equal "NaN"
-
-
-    // float32OfHexString
-    ///////////////////
-
-    try float32OfHexString null |> ignore; Fail()
-    with :? System.ArgumentNullException -> ()
-
-    let checkFormatError s =
-        try float32OfHexString s |> ignore; Fail ()
-        with :? System.FormatException -> ()
-
-    checkFormatError ""
-    checkFormatError "."
-    checkFormatError "p1"
-    checkFormatError ".p1"
-    checkFormatError "1x1"
-    checkFormatError "x1"
-    checkFormatError "0xx1"
-    checkFormatError "0x/"
-    checkFormatError "0x:"
-    checkFormatError "0x@"
-    checkFormatError "0xG"
-    checkFormatError "0x`"
-    checkFormatError "0xg"
-    checkFormatError "0.1pp1"
-    checkFormatError "0.1p+"
-    checkFormatError "0.1p-"
-    checkFormatError "0.fg"
-    checkFormatError "1.0 "
-    checkFormatError "1.."
-    checkFormatError "1.0."
-
-    float32OfHexString "Inf"      |> Equal System.Single.PositiveInfinity
-
-    float32OfHexString "iNf"      |> Equal System.Single.PositiveInfinity
-    float32OfHexString "Infinity" |> Equal System.Single.PositiveInfinity
-    float32OfHexString "+InFinITy" |> Equal System.Single.PositiveInfinity
-    float32OfHexString "-Inf"      |> Equal (-System.Single.PositiveInfinity)
-    float32OfHexString "-InFinITy" |> Equal (-System.Single.PositiveInfinity)
-    float32OfHexString "NaN" |> BEqual System.Single.NaN
-    float32OfHexString "-nAn" |> BEqual System.Single.NaN
-    float32OfHexString "+Nan" |> BEqual System.Single.NaN
-
-    float32OfHexString "001"           |> Equal 1.0f
-    float32OfHexString "1."            |> Equal 1.0f
-    float32OfHexString "1.0"           |> Equal 1.0f
-    float32OfHexString "0x1"           |> Equal 1.0f
-    float32OfHexString "0X1"           |> Equal 1.0f
-    float32OfHexString "0x0001"        |> Equal 1.0f
-    float32OfHexString "0x1."          |> Equal 1.0f
-    float32OfHexString "0x1.0"         |> Equal 1.0f
-    float32OfHexString "0x001.0"       |> Equal 1.0f
-    float32OfHexString "1.0p0"         |> Equal 1.0f
-    float32OfHexString "1.0P0"         |> Equal 1.0f
-    float32OfHexString "001.00p+000"   |> Equal 1.0f
-    float32OfHexString ".100p+004"     |> Equal 1.0f
-    float32OfHexString ".0100p+008"    |> Equal 1.0f
-    float32OfHexString "00.100p+004"   |> Equal 1.0f
-    float32OfHexString "00.0100p+008"  |> Equal 1.0f
-    float32OfHexString "0010.0p-004"   |> Equal 1.0f
-    float32OfHexString "0x1.0p0"       |> Equal 1.0f
-    float32OfHexString "0X1.0P0"       |> Equal 1.0f
-    float32OfHexString "0x001.00p+000" |> Equal 1.0f
-    float32OfHexString "0x00.100p+004" |> Equal 1.0f
-    float32OfHexString "0x.100p+004"   |> Equal 1.0f
-    float32OfHexString "0x0010.0p-004" |> Equal 1.0f
-
-    float32OfHexString "-001"           |> Equal -1.0f
-    float32OfHexString "-1."            |> Equal -1.0f
-    float32OfHexString "-1.0"           |> Equal -1.0f
-    float32OfHexString "-0x1"           |> Equal -1.0f
-    float32OfHexString "-0X1"           |> Equal -1.0f
-    float32OfHexString "-0x0001"        |> Equal -1.0f
-    float32OfHexString "-0x1."          |> Equal -1.0f
-    float32OfHexString "-0x1.0"         |> Equal -1.0f
-    float32OfHexString "-0x001.0"       |> Equal -1.0f
-    float32OfHexString "-1.0p0"         |> Equal -1.0f
-    float32OfHexString "-1.0P0"         |> Equal -1.0f
-    float32OfHexString "-001.00p+000"   |> Equal -1.0f
-    float32OfHexString "-.100p+004"     |> Equal -1.0f
-    float32OfHexString "-.0100p+008"    |> Equal -1.0f
-    float32OfHexString "-00.100p+004"   |> Equal -1.0f
-    float32OfHexString "-00.0100p+008"  |> Equal -1.0f
-    float32OfHexString "-0010.0p-004"   |> Equal -1.0f
-    float32OfHexString "-0x1.0p0"       |> Equal -1.0f
-    float32OfHexString "-0X1.0P0"       |> Equal -1.0f
-    float32OfHexString "-0x001.00p+000" |> Equal -1.0f
-    float32OfHexString "-0x00.100p+004" |> Equal -1.0f
-    float32OfHexString "-0x.100p+004"   |> Equal -1.0f
-    float32OfHexString "-0x0010.0p-004" |> Equal -1.0f
-
-    float32OfHexString "+001"           |> Equal 1.0f
-    float32OfHexString "+1."            |> Equal 1.0f
-    float32OfHexString "+1.0"           |> Equal 1.0f
-    float32OfHexString "+.100p+004"     |> Equal 1.0f
-    float32OfHexString "+0x0010.0p-004" |> Equal 1.0f
-
-    float32OfHexString "0"        |> BEqual 0.f
-    float32OfHexString "0."       |> BEqual 0.f
-    float32OfHexString "0.0"      |> BEqual 0.f
-    float32OfHexString "00.0"     |> BEqual 0.f
-    float32OfHexString "00.000"   |> BEqual 0.f
-    float32OfHexString "00.000p0" |> BEqual 0.f
-    float32OfHexString "00.000p99999999" |> BEqual 0.f
-    float32OfHexString "0x0"        |> BEqual 0.f
-    float32OfHexString "0x0."       |> BEqual 0.f
-    float32OfHexString "0x0.0"      |> BEqual 0.f
-    float32OfHexString "0x00.0"     |> BEqual 0.f
-    float32OfHexString "0x00.000"   |> BEqual 0.f
-    float32OfHexString "0x00.000p0" |> BEqual 0.f
-    float32OfHexString "0x00.000p99999999" |> BEqual 0.f
-    float32OfHexString "100P-2147483639"   |> BEqual 0.f
-    float32OfHexString "100P-2147483640"   |> BEqual 0.f
-    float32OfHexString "100P-2147483647"   |> BEqual 0.f
-    float32OfHexString "100P-9999999999999999999999999"   |> BEqual 0.f
-    float32OfHexString "0.001P-2147483639" |> BEqual 0.f
-    float32OfHexString "0.001P-2147483640" |> BEqual 0.f
-    float32OfHexString "0.001P-2147483647" |> BEqual 0.f
-    float32OfHexString "0.001P-9999999999999999999999999" |> BEqual 0.f
-
-    float32OfHexString "-0"        |> BEqual -0.0f
-    float32OfHexString "-0."       |> BEqual -0.0f
-    float32OfHexString "-0.0"      |> BEqual -0.0f
-    float32OfHexString "-00.0"     |> BEqual -0.0f
-    float32OfHexString "-00.000"   |> BEqual -0.0f
-    float32OfHexString "-00.000p0" |> BEqual -0.f
-    float32OfHexString "-00.000p99999999" |> BEqual -0.f
-    float32OfHexString "-0x0"        |> BEqual -0.0f
-    float32OfHexString "-0x0."       |> BEqual -0.0f
-    float32OfHexString "-0x0.0"      |> BEqual -0.0f
-    float32OfHexString "-0x00.0"     |> BEqual -0.0f
-    float32OfHexString "-0x00.000"   |> BEqual -0.0f
-    float32OfHexString "-0x00.000p0" |> BEqual -0.0f
-    float32OfHexString "-0x00.000p0" |> BEqual -0.f
-    float32OfHexString "-0x00.000p99999999" |> BEqual -0.f
-    float32OfHexString "-100P-2147483639"   |> BEqual -0.f
-    float32OfHexString "-100P-2147483640"   |> BEqual -0.f
-    float32OfHexString "-100P-2147483647"   |> BEqual -0.f
-    float32OfHexString "-100P-9999999999999999999999999"   |> BEqual -0.f
-    float32OfHexString "-0.001P-2147483639" |> BEqual -0.f
-    float32OfHexString "-0.001P-2147483640" |> BEqual -0.f
-    float32OfHexString "-0.001P-2147483647" |> BEqual -0.f
-    float32OfHexString "-0.001P-9999999999999999999999999" |> BEqual -0.f
-
-    float32OfHexString "0x0123" |> Equal (single 0x0123)
-    float32OfHexString "0x4567" |> Equal (single 0x4567)
-    float32OfHexString "0x89ab" |> Equal (single 0x89ab)
-    float32OfHexString "0x89AB" |> Equal (single 0x89ab)
-    float32OfHexString "0xcdef" |> Equal (single 0xcdef)
-    float32OfHexString "0xCDEF" |> Equal (single 0xcdef)
-
-    let v = float32OfHexString "0x1.23456e"
-
-    float32OfHexString "0x123.456e00p-8" |> Equal v
-    float32OfHexString "0x91.a2b700p-7" |> Equal v
-    float32OfHexString "0x48.d15b80p-6" |> Equal v
-    float32OfHexString "0x24.68adc0p-5" |> Equal v
-    float32OfHexString "0x12.3456e0p-4" |> Equal v
-    float32OfHexString "0x9.1a2b70p-3" |> Equal v
-    float32OfHexString "0x4.8d15b8p-2" |> Equal v
-    float32OfHexString "0x2.468adcp-1" |> Equal v
-    float32OfHexString "0x.91a2b70p+1" |> Equal v
-    float32OfHexString "0x.48d15b8p+2" |> Equal v
-    float32OfHexString "0x.2468adcp+3" |> Equal v
-    float32OfHexString "0x.123456ep+4" |> Equal v
-    float32OfHexString "0x.091a2b70p+5" |> Equal v
-    float32OfHexString "0x.048d15b8p+6" |> Equal v
-    float32OfHexString "0x.02468adcp+7" |> Equal v
-    float32OfHexString "0x.0123456ep+8" |> Equal v
-
-
-    // near max
-    float32OfHexString "0x1.fffffep127"  |> Equal max
-    float32OfHexString "0x.1fffffep131"  |> Equal max
-    float32OfHexString "0x.01fffffep135" |> Equal max
-    float32OfHexString "0x1f.ffffep123" |> Equal max
-    float32OfHexString "0x1fffffe.p103" |> Equal max
-    float32OfHexString "-0x1fffffe000.p91" |> Equal (-max)
-
-    float32OfHexString "0x0.ffffff5p128"  |> Equal max
-    float32OfHexString "0x0.ffffff6p128"  |> Equal max
-    float32OfHexString "0x0.ffffff7p128"  |> Equal max
-    float32OfHexString "0x0.ffffff7ffffffffp128" |> Equal max
-
-    let checkOverflow s =
-        try float32OfHexString s |> ignore; Fail ()
-        with :? System.OverflowException -> ()
-
-    checkOverflow "0x0.ffffff8p128"
-    checkOverflow "0x0.ffffff800000p128"
-    checkOverflow "0x0.fffffffp128"
-    checkOverflow "0x1p128"
-    checkOverflow "100P2147483639"
-    checkOverflow "100P2147483640"
-    checkOverflow "100P2147483647"
-    checkOverflow "100P9999999999999999999999999"
-    checkOverflow "0.001P2147483639"
-    checkOverflow "0.001P2147483640"
-    checkOverflow "0.001P2147483647"
-    checkOverflow "0.001P9999999999999999999999999"
-
-    // near 1
-    float32OfHexString "0x1.000001e" |> Equal (1.f + 2.f*eps)
-    float32OfHexString "0x1.000001c" |> Equal (1.f + 2.f*eps)
-    float32OfHexString "0x1.000001a" |> Equal (1.f + 2.f*eps)
-
-    float32OfHexString "0x1.0000018"    |> Equal (1.f + 2.f*eps)
-    float32OfHexString "0x2.0000024p-1" |> Equal (1.f + 2.f*eps)
-    float32OfHexString "0x4.0000048p-2" |> Equal (1.f + 2.f*eps)
-    float32OfHexString "0x8.0000090p-3" |> Equal (1.f + 2.f*eps)
-
-    float32OfHexString "0x1.0000016" |> Equal (1.f + 2.f*eps)
-
-    float32OfHexString "0x1.0000014" |> Equal (1.f + 2.f*eps)
-    float32OfHexString "0x2.0000028p-1" |> Equal (1.f + 2.f*eps)
-    float32OfHexString "0x4.0000050p-2" |> Equal (1.f + 2.f*eps)
-    float32OfHexString "0x8.00000a0p-3"  |> Equal (1.f + 2.f*eps)
-
-    float32OfHexString "0x1.0000012"   |> Equal (1.f + 2.f*eps)
-    float32OfHexString "0x2.0000024p-1"  |> Equal (1.f + 2.f*eps)
-    float32OfHexString "0x4.0000048p-2"  |> Equal (1.f + 2.f*eps)
-    float32OfHexString "0x8.0000090p-3" |> Equal (1.f + 2.f*eps)
-
-    float32OfHexString "0x1.00000110"    |> Equal (1.f + 2.f*eps)
-    float32OfHexString "0x2.00000220p-1"  |> Equal (1.f + 2.f*eps)
-    float32OfHexString "0x4.00000440p-2"  |> Equal (1.f + 2.f*eps)
-    float32OfHexString "0x8.00000880p-3"  |> Equal (1.f + 2.f*eps)
-
-    float32OfHexString "0x1.00000108"    |> Equal (1.f + 2.f*eps)
-    float32OfHexString "0x2.00000210p-1"  |> Equal (1.f + 2.f*eps)
-    float32OfHexString "0x4.00000420p-2"  |> Equal (1.f + 2.f*eps)
-    float32OfHexString "0x8.00000840p-3"  |> Equal (1.f + 2.f*eps)
-
-    float32OfHexString "0x1.00000104"    |> Equal (1.f + 2.f*eps)
-    float32OfHexString "0x2.00000208p-1" |> Equal (1.f + 2.f*eps)
-    float32OfHexString "0x4.0000041p-2"  |> Equal (1.f + 2.f*eps)
-    float32OfHexString "0x8.0000082p-3"  |> Equal (1.f + 2.f*eps)
-
-    float32OfHexString "0x1.000001"    |> Equal (1.f)  // round towards even
-    float32OfHexString "0x2.000002p-1"  |> Equal (1.f)
-    float32OfHexString "0x4.000004p-2"  |> Equal (1.f)
-    float32OfHexString "0x8.00000p-3"  |> Equal (1.f)
-
-    float32OfHexString "0x1.00000100000010000" |> Equal (1.f + 2.f*eps)
-    float32OfHexString "0x1.000000ffffffffff" |> Equal (1.f)
-    float32OfHexString "0x1.000000e" |> Equal (1.f)
-    float32OfHexString "0x1.000000c" |> Equal (1.f)
-    float32OfHexString "0x1.000000a" |> Equal (1.f)
-    float32OfHexString "0x1.0000008" |> Equal (1.f)
-    float32OfHexString "0x1.0000006" |> Equal (1.f)
-    float32OfHexString "0x1.0000004" |> Equal (1.f)
-    float32OfHexString "0x1.0000002" |> Equal (1.f)
-    float32OfHexString "0x1.0000000" |> Equal (1.f)
-    float32OfHexString "0x1.fffffffffP-1" |> Equal (1.f)
-    float32OfHexString "0x1.ffffffeP-1" |> Equal (1.f)
-    float32OfHexString "0x1.ffffffcP-1" |> Equal (1.f)
-    float32OfHexString "0x1.ffffffaP-1" |> Equal (1.f)
-    float32OfHexString "0x1.ffffff8P-1" |> Equal (1.f)
-    float32OfHexString "0x1.ffffff6P-1" |> Equal (1.f)
-    float32OfHexString "0x1.ffffff4P-1" |> Equal (1.f)
-    float32OfHexString "0x1.ffffff2P-1" |> Equal (1.f)
-    float32OfHexString "0x1.ffffffP-1" |> Equal (1.f) // round towards even
-    float32OfHexString "0x1.ffffff0000P-1" |> Equal (1.f)
-    float32OfHexString "0x1.fffffefffffP-1" |> Equal (1.f - eps)
-    float32OfHexString "0x1.fffffee0001P-1" |> Equal (1.f - eps)
-    float32OfHexString "0x1.fffffecP-1" |> Equal (1.f - eps)
-    float32OfHexString "0x1.fffffeaP-1" |> Equal (1.f - eps)
-    float32OfHexString "0x1.fffffe8P-1" |> Equal (1.f - eps)
-    float32OfHexString "0x1.fffffe6P-1" |> Equal (1.f - eps)
-    float32OfHexString "0x1.fffffe4P-1" |> Equal (1.f - eps)
-    float32OfHexString "0x1.fffffe2P-1" |> Equal (1.f - eps)
-    float32OfHexString "0x1.fffffe0P-1" |> Equal (1.f - eps)
-    float32OfHexString "0x1.fffffd001P-1" |> Equal (1.f - eps)
-    float32OfHexString "0x1.fffffdP-1"    |> Equal (1.f - 2.f*eps) // round towards zero
-    float32OfHexString "0x1.fffffd0P-1"   |> Equal (1.f - 2.f*eps)
-    float32OfHexString "0x1.fffffcfffP-1" |> Equal (1.f - 2.f*eps)
-    float32OfHexString "0x1.fffffce0P-1"  |> Equal (1.f - 2.f*eps)
-    float32OfHexString "0x1.fffffc20P-1"  |> Equal (1.f - 2.f*eps)
-
-    float32OfHexString "0x0.800000fP-125" |> Equal (min + minmin)
-    float32OfHexString "0x0.800000eP-125" |> Equal (min + minmin)
-    float32OfHexString "0x0.800000dP-125" |> Equal (min + minmin)
-    float32OfHexString "0x0.800000cP-125" |> Equal (min + minmin)
-    float32OfHexString "0x0.800000bP-125" |> Equal (min + minmin)
-    float32OfHexString "0x0.800000aP-125" |> Equal (min + minmin)
-    float32OfHexString "0x0.8000009P-125" |> Equal (min + minmin)
-    float32OfHexString "0x0.8000008001P-125" |> Equal (min + minmin)
-    float32OfHexString "0x0.8000008P-125" |> Equal (min) // round towards even
-    float32OfHexString "0x0.80000080P-125" |> Equal (min)
-    float32OfHexString "0x0.8000007ffffP-125" |> Equal (min)
-    float32OfHexString "0x0.8000007P-125" |> Equal (min)
-    float32OfHexString "0x0.8000006P-125" |> Equal (min)
-    float32OfHexString "0x0.8000005P-125" |> Equal (min)
-    float32OfHexString "0x0.8000004P-125" |> Equal (min)
-    float32OfHexString "0x0.8000003P-125" |> Equal (min)
-    float32OfHexString "0x0.8000002P-125" |> Equal (min)
-    float32OfHexString "0x0.8000001P-125" |> Equal (min)
-    float32OfHexString "0x0.8000000P-125" |> Equal (min)
-    float32OfHexString "0x0.7ffffffP-125" |> Equal (min)
-    float32OfHexString "0x0.7fffffeP-125" |> Equal (min)
-    float32OfHexString "0x0.7fffffdP-125" |> Equal (min)
-    float32OfHexString "0x0.7fffffcP-125" |> Equal (min)
-    float32OfHexString "0x0.7fffffbP-125" |> Equal (min)
-    float32OfHexString "0x0.7fffffaP-125" |> Equal (min)
-    float32OfHexString "0x0.7fffff9P-125" |> Equal (min)
-    float32OfHexString "0x0.7fffff8P-125" |> Equal (min) // round towards even
-    float32OfHexString "0x0.7fffff7fffP-125" |> Equal (min - minmin)
-    float32OfHexString "0x0.7fffff7P-125" |> Equal (min - minmin)
-    float32OfHexString "0x0.7fffff6P-125" |> Equal (min - minmin)
-    float32OfHexString "0x0.7fffff5P-125" |> Equal (min - minmin)
-    float32OfHexString "0x0.7fffff4P-125" |> Equal (min - minmin)
-    float32OfHexString "0x0.7fffff3P-125" |> Equal (min - minmin)
-    float32OfHexString "0x0.7fffff2P-125" |> Equal (min - minmin)
-    float32OfHexString "0x0.7fffff1P-125" |> Equal (min - minmin)
-    float32OfHexString "0x0.7fffff0P-125" |> Equal (min - minmin)
-    float32OfHexString "0x0.7ffffefP-125" |> Equal (min - minmin)
-    float32OfHexString "0x0.7ffffeeP-125" |> Equal (min - minmin)
-    float32OfHexString "0x0.7ffffedP-125" |> Equal (min - minmin)
-    float32OfHexString "0x0.7ffffecP-125" |> Equal (min - minmin)
-    float32OfHexString "0x0.7ffffebP-125" |> Equal (min - minmin)
-    float32OfHexString "0x0.7ffffeaP-125" |> Equal (min - minmin)
-    float32OfHexString "0x0.7ffffe9P-125" |> Equal (min - minmin)
-    float32OfHexString "0x0.7ffffe8001P-125" |> Equal (min - minmin)
-    float32OfHexString "0x0.7ffffe8P-125" |> Equal (min - 2.f*minmin) // round towards even
-    float32OfHexString "0x0.7ffffe80P-125" |> Equal (min - 2.f*minmin) // round towards even
-    float32OfHexString "0x0.7ffffe7ffP-125" |> Equal (min - 2.f*minmin)
-
-    float32OfHexString "0x0.0000019P-125" |> Equal (2.f*minmin)
-    float32OfHexString "0x0.0000018P-125" |> Equal (2.f*minmin) // round towards even
-    float32OfHexString "0x0.0000017ffP-125" |> Equal (minmin)
-    float32OfHexString "0x0.000001P-125" |> Equal (minmin)
-    float32OfHexString "0x0.0000010P-125" |> Equal (minmin)
-    float32OfHexString "0x0.0000008001P-125" |> Equal (minmin)
-    float32OfHexString "0x0.0000008P-125" |> Equal (0.f) // round towards even
-    float32OfHexString "0x0.0000007ffffP-125" |> Equal (0.f)
-    float32OfHexString "0x1P-150" |> Equal (0.f)
-
-    // round trip checking
-    //////////////////////
-    let rand = System.Random(123)
-    let buffer = Array.zeroCreate 4
-    let randomFloat32() =
-        rand.NextBytes(buffer)
-        System.BitConverter.ToSingle(buffer, 0)
-
-    for i = 0 to 100000 do
-        let f = randomFloat32()
-        let s = float32ToHexString f
-        let f2 = float32OfHexString s
-        True (f = f2 || f <> f)
-
-let run() =
-    testDoubleHexFloat()
-    testSingleHexFloat()
+    Assert.Equal(BitConverter.DoubleToInt64Bits(0.0), BitConverter.DoubleToInt64Bits(actual))
+
+[<Theory>]
+[<InlineData("-0")>]
+[<InlineData("-0.")>]
+[<InlineData("-0.0")>]
+[<InlineData("-00.0")>]
+[<InlineData("-00.000")>]
+[<InlineData("-00.000p0")>]
+[<InlineData("-00.000p99999999")>]
+[<InlineData("-0x0")>]
+[<InlineData("-0x0.")>]
+[<InlineData("-0x0.0")>]
+[<InlineData("-0x00.0")>]
+[<InlineData("-0x00.000")>]
+[<InlineData("-0x00.000p0")>]
+[<InlineData("-0x00.000p0")>]
+[<InlineData("-0x00.000p99999999")>]
+[<InlineData("-100P-2147483639")>]
+[<InlineData("-100P-2147483640")>]
+[<InlineData("-100P-2147483647")>]
+[<InlineData("-100P-9999999999999999999999999")>]
+[<InlineData("-0.001P-2147483639")>]
+[<InlineData("-0.001P-2147483640")>]
+[<InlineData("-0.001P-2147483647")>]
+[<InlineData("-0.001P-9999999999999999999999999")>]
+let ``floatOfHexString generates floats that are binary equivalent to negative 0`` str =
+    let actual = floatOfHexString str
+    Assert.Equal(BitConverter.DoubleToInt64Bits(-0.0), BitConverter.DoubleToInt64Bits(actual))
+
+[<Theory>]
+[<InlineData("0x0123", 0x0123)>]
+[<InlineData("0x4567", 0x4567)>]
+[<InlineData("0x89ab", 0x89ab)>]
+[<InlineData("0x89AB", 0x89ab)>]
+[<InlineData("0xcdef", 0xcdef)>]
+[<InlineData("0xCDEF", 0xcdef)>]
+let ``Not sure what's being tested here`` str expected =
+    let actual = floatOfHexString str
+    Assert.Equal(double expected, actual)
+
+[<Theory>]
+[<InlineData("0x123.456789abcde00p-8")>]
+[<InlineData("0x91.a2b3c4d5e6f00p-7")>]
+[<InlineData("0x48.d159e26af3780p-6")>]
+[<InlineData("0x24.68acf13579bc0p-5")>]
+[<InlineData("0x12.3456789abcde0p-4")>]
+[<InlineData("0x9.1a2b3c4d5e6fp-3")>]
+[<InlineData("0x4.8d159e26af378p-2")>]
+[<InlineData("0x2.468acf13579bcp-1")>]
+[<InlineData("0x.91a2b3c4d5e6f0p+1")>]
+[<InlineData("0x.48d159e26af378p+2")>]
+[<InlineData("0x.2468acf13579bcp+3")>]
+[<InlineData("0x.123456789abcdep+4")>]
+[<InlineData("0x.091a2b3c4d5e6f0p+5")>]
+[<InlineData("0x.048d159e26af378p+6")>]
+[<InlineData("0x.02468acf13579bcp+7")>]
+[<InlineData("0x.0123456789abcdep+8")>]
+let ``Not sure what's being tested here also`` str =
+    let expected = floatOfHexString "0x1.23456789abcde"
+    let actual = floatOfHexString str
+    
+    Assert.Equal(expected, actual)
+
+[<Theory>]
+[<InlineData("0x1.fffffffffffffp1023")>]
+[<InlineData("0x.1fffffffffffffp1027")>]
+[<InlineData("0x.01fffffffffffffp1031")>]
+[<InlineData("0x1f.ffffffffffffp1019")>]
+[<InlineData("0x1fffffffffffff.p971")>]
+[<InlineData("0x1.fffffffffffff5p1023")>]
+[<InlineData("0x1.fffffffffffff6p1023")>]
+[<InlineData("0x1.fffffffffffff7p1023")>]
+[<InlineData("0x1.fffffffffffff7ffffffffp1023")>]
+let ``floatOfHexString generates max value floats for positive values near max value`` str =
+    let actual = floatOfHexString str
+    Assert.Equal(Double.MaxValue, actual)
+
+[<Theory>]
+[<InlineData("-0x1fffffffffffff000.p959")>]
+let ``floatOfHexString generates max value floats for negative values near max value`` str =
+    let actual = floatOfHexString str
+    Assert.Equal(-Double.MaxValue, actual)
+
+[<Theory>]
+[<InlineData("0x1.fffffffffffff8p1023")>]
+[<InlineData("0x1.fffffffffffff800000p1023")>]
+[<InlineData("0x1.ffffffffffffffp1023")>]
+[<InlineData("0x1p1024")>]
+[<InlineData("100P2147483639")>]
+[<InlineData("100P2147483640")>]
+[<InlineData("100P2147483647")>]
+[<InlineData("100P9999999999999999999999999")>]
+[<InlineData("0.001P2147483639")>]
+[<InlineData("0.001P2147483640")>]
+[<InlineData("0.001P2147483647")>]
+[<InlineData("0.001P9999999999999999999999999")>]
+let ``floatOfHexString throws a System Overflow exception when passed values that are too large`` str =
+    Assert.Throws<OverflowException>(fun () -> floatOfHexString str |> ignore)
+
+[<Theory>]
+[<InlineData("0x1.0000000000000f")>]
+[<InlineData("0x1.0000000000000e")>]
+[<InlineData("0x1.0000000000000d")>]
+[<InlineData("0x1.0000000000000c")>]
+[<InlineData("0x2.00000000000018p-1")>] 
+[<InlineData("0x4.0000000000003p-2")>]
+[<InlineData("0x8.0000000000006p-3")>]
+[<InlineData("0x1.0000000000000b")>]
+[<InlineData("0x1.0000000000000a")>]
+[<InlineData("0x2.00000000000014p-1")>]
+[<InlineData("0x4.00000000000028p-2")>]
+[<InlineData("0x8.0000000000005p-3")>]
+[<InlineData("0x1.00000000000009")>]
+[<InlineData("0x2.00000000000012p-1")>]
+[<InlineData("0x4.00000000000024p-2")>]
+[<InlineData("0x8.00000000000048p-3")>]
+[<InlineData("0x1.000000000000088")>]
+[<InlineData("0x2.00000000000011p-1")>]
+[<InlineData("0x4.00000000000022p-2")>]
+[<InlineData("0x8.00000000000044p-3")>]
+[<InlineData("0x1.000000000000084")>]
+[<InlineData("0x2.000000000000108p-1")>]
+[<InlineData("0x4.00000000000021p-2")>]
+[<InlineData("0x8.00000000000042p-3")>]
+[<InlineData("0x1.000000000000082")>]
+[<InlineData("0x2.000000000000104p-1")>]
+[<InlineData("0x4.000000000000208p-2")>]
+[<InlineData("0x8.00000000000041p-3")>]
+[<InlineData("0x1.0000000000000800000010000")>]
+let ``floatOfHexString handles values near 1`` str =
+    let expected = 1.0 + 2.*eps
+    
+    let actual = floatOfHexString str
+    
+    Assert.Equal(expected, actual)
+
+let nearestValueData : obj[] list =
+    [
+        [| "0x1.00000000000008"   ; 1.0 |]
+        [| "0x2.0000000000001p-1" ; 1.0 |]
+        [| "0x4.0000000000002p-2" ; 1.0 |]
+        [| "0x8.0000000000004p-3" ; 1.0 |]
+        [| "0x1.00000000000007ffffffffff"; 1.0 |]
+        [| "0x1.00000000000007"; 1.0 |]
+        [| "0x1.00000000000006"; 1.0 |]
+        [| "0x1.00000000000005"; 1.0 |]
+        [| "0x1.00000000000004"; 1.0 |]
+        [| "0x1.00000000000003"; 1.0 |]
+        [| "0x1.00000000000002"; 1.0 |]
+        [| "0x1.00000000000001"; 1.0 |]
+        [| "0x1.00000000000000"; 1.0 |]
+        [| "0x1.ffffffffffffffffP-1"; 1.0 |]
+        [| "0x1.fffffffffffffeP-1"; 1.0 |]
+        [| "0x1.fffffffffffffdP-1"; 1.0 |]
+        [| "0x1.fffffffffffffcP-1"; 1.0 |]
+        [| "0x1.fffffffffffffbP-1"; 1.0 |]
+        [| "0x1.fffffffffffffaP-1"; 1.0 |]
+        [| "0x1.fffffffffffff9P-1"; 1.0 |]
+        [| "0x1.fffffffffffff8P-1"; 1.0 |]
+        [| "0x1.fffffffffffff800P-1"; 1.0 |]
+        [| "0x1.fffffffffffff7ffffffP-1"; 1.0 - eps |]
+        [| "0x1.fffffffffffff7000001P-1"; 1.0 - eps |]
+        [| "0x1.fffffffffffff7P-1"; 1.0 - eps |]
+        [| "0x1.fffffffffffff6P-1"; 1.0 - eps |]
+        [| "0x1.fffffffffffff5P-1"; 1.0 - eps |]
+        [| "0x1.fffffffffffff4P-1"; 1.0 - eps |]
+        [| "0x1.fffffffffffff3P-1"; 1.0 - eps |]
+        [| "0x1.fffffffffffff2P-1"; 1.0 - eps |]
+        [| "0x1.fffffffffffff1P-1"; 1.0 - eps |]
+        [| "0x1.fffffffffffff0P-1"; 1.0 - eps |]
+        [| "0x1.ffffffffffffefP-1"; 1.0 - eps |]
+        [| "0x1.ffffffffffffe8001P-1"; 1.0 - eps |]
+        [| "0x1.ffffffffffffe8P-1"; 1.0 - 2.*eps |]
+        [| "0x1.ffffffffffffe80P-1"; 1.0 - 2.*eps |]
+        [| "0x1.ffffffffffffe7ffffP-1"; 1.0 - 2.*eps |]
+        [| "0x1.ffffffffffffe70P-1"; 1.0 - 2.*eps |]
+        [| "0x1.ffffffffffffe1P-1"; 1.0 - 2.*eps |]
+        [| "0x1.0000000000000fP-1022"; min + minmin |]
+        [| "0x1.0000000000000eP-1022"; min + minmin |]
+        [| "0x1.0000000000000dP-1022"; min + minmin |]
+        [| "0x1.0000000000000cP-1022"; min + minmin |]
+        [| "0x1.0000000000000bP-1022"; min + minmin |]
+        [| "0x1.0000000000000aP-1022"; min + minmin |]
+        [| "0x1.00000000000009P-1022"; min + minmin |]
+        [| "0x1.00000000000008001P-1022"; min + minmin |]
+        [| "0x1.00000000000008P-1022"; min |]
+        [| "0x1.000000000000080P-1022"; min |]
+        [| "0x1.00000000000007ffffP-1022"; min |]
+        [| "0x1.00000000000007P-1022"; min |]
+        [| "0x1.00000000000006P-1022"; min |]
+        [| "0x1.00000000000005P-1022"; min |]
+        [| "0x1.00000000000004P-1022"; min |]
+        [| "0x1.00000000000003P-1022"; min |]
+        [| "0x1.00000000000002P-1022"; min |]
+        [| "0x1.00000000000001P-1022"; min |]
+        [| "0x1.00000000000000P-1022"; min |]
+        [| "0x0.ffffffffffffffP-1022"; min |]
+        [| "0x0.fffffffffffffeP-1022"; min |]
+        [| "0x0.fffffffffffffdP-1022"; min |]
+        [| "0x0.fffffffffffffcP-1022"; min |]
+        [| "0x0.fffffffffffffbP-1022"; min |]
+        [| "0x0.fffffffffffffaP-1022"; min |]
+        [| "0x0.fffffffffffff9P-1022"; min |]
+        [| "0x0.fffffffffffff8P-1022"; min |]
+        [| "0x0.fffffffffffff7fffP-1022"; min - minmin |]
+        [| "0x0.fffffffffffff7P-1022"; min - minmin |]
+        [| "0x0.fffffffffffff6P-1022"; min - minmin |]
+        [| "0x0.fffffffffffff5P-1022"; min - minmin |]
+        [| "0x0.fffffffffffff4P-1022"; min - minmin |]
+        [| "0x0.fffffffffffff3P-1022"; min - minmin |]
+        [| "0x0.fffffffffffff2P-1022"; min - minmin |]
+        [| "0x0.fffffffffffff1P-1022"; min - minmin |]
+        [| "0x0.fffffffffffff0P-1022"; min - minmin |]
+        [| "0x0.ffffffffffffefP-1022"; min - minmin |]
+        [| "0x0.ffffffffffffeeP-1022"; min - minmin |]
+        [| "0x0.ffffffffffffedP-1022"; min - minmin |]
+        [| "0x0.ffffffffffffecP-1022"; min - minmin |]
+        [| "0x0.ffffffffffffebP-1022"; min - minmin |]
+        [| "0x0.ffffffffffffeaP-1022"; min - minmin |]
+        [| "0x0.ffffffffffffe9P-1022"; min - minmin |]
+        [| "0x0.ffffffffffffe8001P-1022"; min - minmin |]
+        [| "0x0.ffffffffffffe8P-1022"; min - 2.*minmin |]
+        [| "0x0.ffffffffffffe80P-1022"; min - 2.*minmin |]
+        [| "0x0.ffffffffffffe7ffP-1022"; min - 2.*minmin |]
+        [| "0x0.00000000000019P-1022"; 2.*minmin |]
+        [| "0x0.00000000000018P-1022"; 2.*minmin |]
+        [| "0x0.00000000000017ffP-1022"; minmin |]
+        [| "0x0.0000000000001P-1022"; minmin |]
+        [| "0x0.00000000000010P-1022"; minmin |]
+        [| "0x0.00000000000008001P-1022"; minmin |]
+        [| "0x0.00000000000008P-1022"; 0. |]
+        [| "0x0.00000000000007ffffP-1022"; 0. |]
+        [| "0x1.P-1075"; 0. |]
+    ]
+
+[<Theory>]
+[<MemberData(nameof(nearestValueData))>]
+let ``floatOfHexString rounds to the nearest even value`` str expected =
+    let actual = floatOfHexString str
+    
+    Assert.Equal(expected, actual)

--- a/Test/Test.targets
+++ b/Test/Test.targets
@@ -30,6 +30,7 @@
     <Compile Include="BufferTests.fs" />
     <Compile Include="CharSetTests.fs" />
     <Compile Include="HexFloatTests.fs" />
+    <Compile Include="HexFloat32Tests.fs" />
     <Compile Include="TextTests.fs" />
     <Compile Include="CloningTests.fs" />
     <Compile Include="StringBufferTests.fs" />

--- a/Test/Test.targets
+++ b/Test/Test.targets
@@ -17,7 +17,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Xunit" Version="2.4.2" />
+    <PackageReference Include="FsCheck.Xunit" Version="2.16.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <None Include="Test.targets" />
+    <Compile Include="Common.fs" />
+    <Compile Include="Generators.fs" />
     <Compile Include="Test.fs" />
     <Compile Include="BufferTests.fs" />
     <Compile Include="CharSetTests.fs" />


### PR DESCRIPTION
Preliminary work on updating FParsec's test framework to utilize Xunit and FsCheck property based tests to resolve issue #96.

- [X] BufferTests
- [x] CharSetTests
- [x] HexFloatTests
- [ ] TextTests
- [ ] ~~CloningTests~~
- [ ] ~~StringBufferTests~~
- [ ] CharStreamTests
- [ ] PrimitivesTests
- [ ] CharParsersTests
- [ ] IdentifierValidatorTests
- [ ] OperatorPrecedenceParserTests
- [ ] RangeTests
- [ ] StaticMappingTests
- [ ] Generator and Shrink tests for custom FsCheck generators
- [ ] Identify and implement missing tests based on code coverage