### PR TITLE
Naming `ParseResult` fields.

### DIFF
--- a/FParsec/CharParsers.fs
+++ b/FParsec/CharParsers.fs
@@ -43,15 +43,15 @@ let float32OfHexString = HexFloat.SingleFromHexString
 
 [<StructuredFormatDisplay("{StructuredFormatDisplay}")>]
 type ParserResult<'Result,'UserState> =
-     | Success of 'Result * 'UserState * Position
-     | Failure of string * ParserError * 'UserState
+     | Success of result: 'Result * state: 'UserState * endPosition: Position
+     | Failure of message: string * error: ParserError * state: 'UserState
      with
         member private t.StructuredFormatDisplay =
             match t with
-            | Success(r,_,_) ->
+            | Success(result=r) ->
                 if typeof<'Result> = typeof<unit> then "Success: ()"
                 else sprintf "Success: %A" r
-            | Failure(msg,_,_) ->
+            | Failure(message=msg) ->
                 sprintf "Failure:\n%s" msg
 
 let internal applyParser (parser: Parser<'Result,'UserState>) (stream: CharStream<'UserState>) =

--- a/FParsec/CharParsers.fsi
+++ b/FParsec/CharParsers.fsi
@@ -13,12 +13,12 @@ open Primitives
 
 /// Values of this type are returned by the runParser functions (not by `Parser<_,_>` functions).
 type ParserResult<'Result,'UserState> =
-     /// Success(result, userState, endPos) holds the result and the user state returned by a successful parser,
+     /// Success(result, state, endPosition) holds the result and the user state returned by a successful parser,
      /// together with the position where the parser stopped.
-     | Success of 'Result * 'UserState * Position
-     /// Failure(errorAsString, error, suserState) holds the parser error and the user state returned by a failing parser,
+     | Success of result: 'Result * state: 'UserState * endPosition: Position
+     /// Failure(message, error, suserState) holds the parser error and the user state returned by a failing parser,
      /// together with a string representation of the parser error.
-     | Failure of string * ParserError * 'UserState
+     | Failure of message: string * error: ParserError * state: 'UserState
 
 /// `runParserOnString p ustate streamName str` runs the parser `p` directly on the content of the string `str`,
 /// starting with the initial user state `ustate`. The `streamName` is used in error messages to describe

--- a/Samples/Calculator/calculator.fs
+++ b/Samples/Calculator/calculator.fs
@@ -47,9 +47,9 @@ let calculate s = run completeExpression s
 
 let equals expectedValue r =
     match r with
-    | Success (v, _, _) when v = expectedValue -> ()
-    | Success (v, _, _)     -> failwith "Math is hard, let's go shopping!"
-    | Failure (msg, err, _) -> printf "%s" msg; failwith msg
+    | Success (result=v) when v = expectedValue -> ()
+    | Success _ -> failwith "Math is hard, let's go shopping!"
+    | Failure (message=msg) -> printf "%s" msg; failwith msg
 
 let test() =
     calculate "10.5 + 123.25 + 877"  |> equals 1010.75

--- a/Samples/FSharpParsingSample/FParsecVersion/main.fs
+++ b/Samples/FSharpParsingSample/FParsecVersion/main.fs
@@ -23,8 +23,8 @@ let main(argv: string[]) =
 
     let myProg =
         match result with
-        | Success (v, _, _) -> v
-        | Failure (msg, _, _) ->
+        | Success (result=v) -> v
+        | Failure (message=msg) ->
             System.Console.WriteLine(msg)
             exit 1
 

--- a/Samples/JSON/main.fs
+++ b/Samples/JSON/main.fs
@@ -22,10 +22,10 @@ let main(args: string[]) =
     let result = parseJsonFile args[0] System.Text.Encoding.UTF8
     // for the moment we just print out the AST
     match result with
-    | Success (v, _, _) ->
+    | Success (result=v) ->
         printf "The AST of the input file is:\n%A\n" v
         0
-    | Failure (msg, err, _) ->
+    | Failure (message=msg) ->
         printfn "%s" msg
         1
 

--- a/Samples/PEG/main.fs
+++ b/Samples/PEG/main.fs
@@ -22,6 +22,6 @@ let main(args: string[]) =
     let result = runParserOnFile Parser.pGrammar () fileName System.Text.Encoding.UTF8
     // for the moment we just print out the AST
     match result with
-    | Success (v, _, _) -> printf "The ast for the input file is:\n%A\n" v
-    | Failure (msg, err, _) -> printf "%s\n" msg
+    | Success (result=v) -> printf "The ast for the input file is:\n%A\n" v
+    | Failure (message=msg) -> printf "%s\n" msg
     0

--- a/Samples/Tutorial/tutorial.fs
+++ b/Samples/Tutorial/tutorial.fs
@@ -9,8 +9,8 @@ open FParsec
 
 let test p str =
     match run p str with
-    | Success(result, _, _)   -> printfn "Success: %A" result
-    | Failure(errorMsg, _, _) -> printfn "Failure: %s" errorMsg
+    | Success(result=result)   -> printfn "Success: %A" result
+    | Failure(message=errorMsg) -> printfn "Failure: %s" errorMsg
 
 test pfloat "1.25"
 test pfloat "1.25E 2"

--- a/Test/CharParsersTests.fs
+++ b/Test/CharParsersTests.fs
@@ -144,7 +144,7 @@ let testSpecialCharParsers() =
     let count p = many p |>> List.fold (fun c x -> c + 1) 0
 
     match run (count unicodeNewline) "\n\r\r\n\u0085\u2028\u2029\r\n" with
-    | Success(c,_,pos) -> c |> Equal 7; pos.Index |> Equal 9L; pos.Line |> Equal 8L; pos.Column |> Equal 1L
+    | Success(result=c;endPosition=pos) -> c |> Equal 7; pos.Index |> Equal 9L; pos.Line |> Equal 8L; pos.Column |> Equal 1L
     | Failure _        -> Fail()
 
     spaces  |> ROk ""   0 ()
@@ -162,17 +162,17 @@ let testSpecialCharParsers() =
     unicodeSpaces1 |> ROk " \u200A" 2 ()
 
     match run spaces "\n \r\t\t\r\n\n " with
-    | Success(_, _, pos) -> pos.Index |> Equal 9L; pos.Line |> Equal 5L; pos.Column |> Equal 2L
+    | Success(endPosition=pos) -> pos.Index |> Equal 9L; pos.Line |> Equal 5L; pos.Column |> Equal 2L
     | _ -> Fail()
     match run spaces1 "\n \r\t\t\r\n\n " with
-    | Success(_, _, pos) -> pos.Index |> Equal 9L; pos.Line |> Equal 5L; pos.Column |> Equal 2L
+    | Success(endPosition=pos) -> pos.Index |> Equal 9L; pos.Line |> Equal 5L; pos.Column |> Equal 2L
     | _ -> Fail()
 
     match run unicodeSpaces "\n \r\t\t\r\n\n \u0085\u000C\u2028\u2029 \r\n\t\u200A" with
-    | Success(_, _, pos) -> pos.Index |> Equal 18L; pos.Line |> Equal 9L; pos.Column |> Equal 3L
+    | Success(endPosition=pos) -> pos.Index |> Equal 18L; pos.Line |> Equal 9L; pos.Column |> Equal 3L
     | _ -> Fail()
     match run unicodeSpaces1 "\n \r\t\t\r\n\n \u0085\u000C\u2028\u2029 \r\n\t\u200A" with
-    | Success(_, _, pos) -> pos.Index |> Equal 18L; pos.Line |> Equal 9L; pos.Column |> Equal 3L
+    | Success(endPosition=pos) -> pos.Index |> Equal 18L; pos.Line |> Equal 9L; pos.Column |> Equal 3L
     | _ -> Fail()
 
     eof |> ROk "" 0 ()

--- a/Test/IdentifierValidatorTests.fs
+++ b/Test/IdentifierValidatorTests.fs
@@ -1812,8 +1812,8 @@ open FParsec
 
 let testCharPredicates() =
     let xidStartRanges, xidContinueRanges = match Parser.parseXIdRanges() with
-                                            | CharParsers.Success(ranges, _, _ ) -> ranges
-                                            | CharParsers.Failure(msg,_,_) -> failwith msg
+                                            | CharParsers.Success(result=ranges) -> ranges
+                                            | CharParsers.Failure(message=msg) -> failwith msg
 
     let checkPredicate fBmp fSmp ranges =
         let mutable lastLast = -1


### PR DESCRIPTION
In using the library, I found that I want to deconstruct ParseResult using named fields rather than positional; also, it is not considered a good practice to [leave DU fields unnamed](https://github.com/dotnet/fsharp/issues/15665).

So I'm suggesting we look at those changes, and consider if they are aligned with the style of the library.

If so, I can spend some time in reviewing the documentation and doing similar stylistic adjustment in some of the code examples, if desired.